### PR TITLE
Bootstrap migrate non-modifications

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1,13163 +1,2873 @@
-@charset "UTF-8";
-/*!
- * Bootstrap  v5.3.2 (https://getbootstrap.com/)
- * Copyright 2011-2023 The Bootstrap Authors
- * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
- */
 :root,
 [data-bs-theme=light] {
-  --bs-blue: #0d6efd;
-  --bs-indigo: #6610f2;
-  --bs-purple: #6f42c1;
-  --bs-pink: #d63384;
-  --bs-red: #dc3545;
-  --bs-orange: #fd7e14;
-  --bs-yellow: #ffc107;
-  --bs-green: #198754;
-  --bs-teal: #20c997;
-  --bs-cyan: #0dcaf0;
-  --bs-black: #000;
-  --bs-white: #fff;
-  --bs-gray: #6c757d;
-  --bs-gray-dark: #343a40;
-  --bs-gray-100: #f8f9fa;
-  --bs-gray-200: #e9ecef;
-  --bs-gray-300: #dee2e6;
-  --bs-gray-400: #ced4da;
-  --bs-gray-500: #adb5bd;
-  --bs-gray-600: #6c757d;
-  --bs-gray-700: #495057;
-  --bs-gray-800: #343a40;
-  --bs-gray-900: #212529;
-  --bs-primary: #5149e5;
-  --bs-secondary: #9932e7;
-  --bs-success: #05b171;
-  --bs-info: #25c2e3;
-  --bs-warning: #faae42;
-  --bs-danger: #ea4444;
-  --bs-light: #ededed;
-  --bs-dark: #293134;
-  --bs-primary-rgb: 81, 73, 229;
-  --bs-secondary-rgb: 153, 50, 231;
-  --bs-success-rgb: 5, 177, 113;
-  --bs-info-rgb: 37, 194, 227;
-  --bs-warning-rgb: 250, 174, 66;
-  --bs-danger-rgb: 234, 68, 68;
-  --bs-light-rgb: 237, 237, 237;
-  --bs-dark-rgb: 41, 49, 52;
-  --bs-primary-text-emphasis: #201d5c;
-  --bs-secondary-text-emphasis: #3d145c;
-  --bs-success-text-emphasis: #02472d;
-  --bs-info-text-emphasis: #0f4e5b;
-  --bs-warning-text-emphasis: #64461a;
-  --bs-danger-text-emphasis: #5e1b1b;
-  --bs-light-text-emphasis: #495057;
-  --bs-dark-text-emphasis: #495057;
-  --bs-primary-bg-subtle: #dcdbfa;
-  --bs-secondary-bg-subtle: #ebd6fa;
-  --bs-success-bg-subtle: #cdefe3;
-  --bs-info-bg-subtle: #d3f3f9;
-  --bs-warning-bg-subtle: #feefd9;
-  --bs-danger-bg-subtle: #fbdada;
-  --bs-light-bg-subtle: #fcfcfd;
-  --bs-dark-bg-subtle: #ced4da;
-  --bs-primary-border-subtle: #b9b6f5;
-  --bs-secondary-border-subtle: #d6adf5;
-  --bs-success-border-subtle: #9be0c6;
-  --bs-info-border-subtle: #a8e7f4;
-  --bs-warning-border-subtle: #fddfb3;
-  --bs-danger-border-subtle: #f7b4b4;
-  --bs-light-border-subtle: #e9ecef;
-  --bs-dark-border-subtle: #adb5bd;
-  --bs-white-rgb: 255, 255, 255;
-  --bs-black-rgb: 0, 0, 0;
-  --bs-font-sans-serif: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  --bs-font-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  --bs-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0));
-  --bs-body-font-family: var(--bs-font-sans-serif);
-  --bs-body-font-size: 0.875rem;
-  --bs-body-font-weight: 400;
-  --bs-body-line-height: 1.5;
-  --bs-body-color: #212529;
-  --bs-body-color-rgb: 33, 37, 41;
-  --bs-body-bg: #fff;
-  --bs-body-bg-rgb: 255, 255, 255;
-  --bs-emphasis-color: #000;
-  --bs-emphasis-color-rgb: 0, 0, 0;
-  --bs-secondary-color: rgba(33, 37, 41, 0.75);
-  --bs-secondary-color-rgb: 33, 37, 41;
-  --bs-secondary-bg: #e9ecef;
-  --bs-secondary-bg-rgb: 233, 236, 239;
-  --bs-tertiary-color: rgba(33, 37, 41, 0.5);
-  --bs-tertiary-color-rgb: 33, 37, 41;
-  --bs-tertiary-bg: #f8f9fa;
-  --bs-tertiary-bg-rgb: 248, 249, 250;
-  --bs-heading-color: inherit;
-  --bs-link-color: #5149e5;
-  --bs-link-color-rgb: 81, 73, 229;
-  --bs-link-decoration: underline;
-  --bs-link-hover-color: #413ab7;
-  --bs-link-hover-color-rgb: 65, 58, 183;
-  --bs-code-color: #d63384;
-  --bs-highlight-color: #212529;
-  --bs-highlight-bg: #fff3cd;
-  --bs-border-width: 1px;
-  --bs-border-style: solid;
-  --bs-border-color: #dee2e6;
-  --bs-border-color-translucent: rgba(0, 0, 0, 0.175);
-  --bs-border-radius: 0.5rem;
-  --bs-border-radius-sm: 0.25rem;
-  --bs-border-radius-lg: 0.5rem;
-  --bs-border-radius-xl: 1rem;
-  --bs-border-radius-xxl: 2rem;
-  --bs-border-radius-2xl: var(--bs-border-radius-xxl);
-  --bs-border-radius-pill: 50rem;
-  --bs-box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
-  --bs-box-shadow-sm: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
-  --bs-box-shadow-lg: 0 1rem 3rem rgba(0, 0, 0, 0.175);
-  --bs-box-shadow-inset: inset 0 1px 2px rgba(0, 0, 0, 0.075);
-  --bs-focus-ring-width: 0.25rem;
-  --bs-focus-ring-opacity: 0.25;
-  --bs-focus-ring-color: rgba(81, 73, 229, 0.25);
-  --bs-form-valid-color: #05b171;
-  --bs-form-valid-border-color: #05b171;
-  --bs-form-invalid-color: #ea4444;
-  --bs-form-invalid-border-color: #ea4444;
+    --bs-primary: #5149e5;
+    --bs-secondary: #9932e7;
+    --bs-success: #05b171;
+    --bs-info: #25c2e3;
+    --bs-warning: #faae42;
+    --bs-danger: #ea4444;
+    --bs-light: #ededed;
+    --bs-dark: #293134;
+    --bs-primary-rgb: 81, 73, 229;
+    --bs-secondary-rgb: 153, 50, 231;
+    --bs-success-rgb: 5, 177, 113;
+    --bs-info-rgb: 37, 194, 227;
+    --bs-warning-rgb: 250, 174, 66;
+    --bs-danger-rgb: 234, 68, 68;
+    --bs-light-rgb: 237, 237, 237;
+    --bs-dark-rgb: 41, 49, 52;
+    --bs-primary-text-emphasis: #201d5c;
+    --bs-secondary-text-emphasis: #3d145c;
+    --bs-success-text-emphasis: #02472d;
+    --bs-info-text-emphasis: #0f4e5b;
+    --bs-warning-text-emphasis: #64461a;
+    --bs-danger-text-emphasis: #5e1b1b;
+
+
+    --bs-dark-text-emphasis: #495057;
+    --bs-primary-bg-subtle: #dcdbfa;
+    --bs-secondary-bg-subtle: #ebd6fa;
+    --bs-success-bg-subtle: #cdefe3;
+    --bs-info-bg-subtle: #d3f3f9;
+    --bs-warning-bg-subtle: #feefd9;
+    --bs-danger-bg-subtle: #fbdada;
+
+    --bs-primary-border-subtle: #b9b6f5;
+    --bs-secondary-border-subtle: #d6adf5;
+    --bs-success-border-subtle: #9be0c6;
+    --bs-info-border-subtle: #a8e7f4;
+    --bs-warning-border-subtle: #fddfb3;
+    --bs-danger-border-subtle: #f7b4b4;
+
+    --bs-body-font-size: 0.875rem;
+
+    --bs-link-color: #5149e5;
+    --bs-link-color-rgb: 81, 73, 229;
+
+    --bs-link-hover-color: #413ab7;
+    --bs-link-hover-color-rgb: 65, 58, 183;
+
+    --bs-border-radius: 0.5rem;
+
+    --bs-focus-ring-color: rgba(81, 73, 229, 0.25);
+    --bs-form-valid-color: #05b171;
+    --bs-form-valid-border-color: #05b171;
+    --bs-form-invalid-color: #ea4444;
+    --bs-form-invalid-border-color: #ea4444;
 }
 
 [data-bs-theme=dark] {
-  color-scheme: dark;
-  --bs-body-color: #dee2e6;
-  --bs-body-color-rgb: 222, 226, 230;
-  --bs-body-bg: #212529;
-  --bs-body-bg-rgb: 33, 37, 41;
-  --bs-emphasis-color: #fff;
-  --bs-emphasis-color-rgb: 255, 255, 255;
-  --bs-secondary-color: rgba(222, 226, 230, 0.75);
-  --bs-secondary-color-rgb: 222, 226, 230;
-  --bs-secondary-bg: #343a40;
-  --bs-secondary-bg-rgb: 52, 58, 64;
-  --bs-tertiary-color: rgba(222, 226, 230, 0.5);
-  --bs-tertiary-color-rgb: 222, 226, 230;
-  --bs-tertiary-bg: #2b3035;
-  --bs-tertiary-bg-rgb: 43, 48, 53;
-  --bs-primary-text-emphasis: #9792ef;
-  --bs-secondary-text-emphasis: #c284f1;
-  --bs-success-text-emphasis: #69d0aa;
-  --bs-info-text-emphasis: #7cdaee;
-  --bs-warning-text-emphasis: #fcce8e;
-  --bs-danger-text-emphasis: #f28f8f;
-  --bs-light-text-emphasis: #f8f9fa;
-  --bs-dark-text-emphasis: #dee2e6;
-  --bs-primary-bg-subtle: #100f2e;
-  --bs-secondary-bg-subtle: #1f0a2e;
-  --bs-success-bg-subtle: #012317;
-  --bs-info-bg-subtle: #07272d;
-  --bs-warning-bg-subtle: #32230d;
-  --bs-danger-bg-subtle: #2f0e0e;
-  --bs-light-bg-subtle: #343a40;
-  --bs-dark-bg-subtle: #1a1d20;
-  --bs-primary-border-subtle: #312c89;
-  --bs-secondary-border-subtle: #5c1e8b;
-  --bs-success-border-subtle: #036a44;
-  --bs-info-border-subtle: #167488;
-  --bs-warning-border-subtle: #966828;
-  --bs-danger-border-subtle: #8c2929;
-  --bs-light-border-subtle: #495057;
-  --bs-dark-border-subtle: #343a40;
-  --bs-heading-color: inherit;
-  --bs-link-color: #9792ef;
-  --bs-link-hover-color: #aca8f2;
-  --bs-link-color-rgb: 151, 146, 239;
-  --bs-link-hover-color-rgb: 172, 168, 242;
-  --bs-code-color: #e685b5;
-  --bs-highlight-color: #dee2e6;
-  --bs-highlight-bg: #664d03;
-  --bs-border-color: #495057;
-  --bs-border-color-translucent: rgba(255, 255, 255, 0.15);
-  --bs-form-valid-color: #75b798;
-  --bs-form-valid-border-color: #75b798;
-  --bs-form-invalid-color: #ea868f;
-  --bs-form-invalid-border-color: #ea868f;
+    --bs-primary-text-emphasis: #9792ef;
+    --bs-secondary-text-emphasis: #c284f1;
+    --bs-success-text-emphasis: #69d0aa;
+    --bs-info-text-emphasis: #7cdaee;
+    --bs-warning-text-emphasis: #fcce8e;
+    --bs-danger-text-emphasis: #f28f8f;
+
+    --bs-primary-bg-subtle: #100f2e;
+    --bs-secondary-bg-subtle: #1f0a2e;
+    --bs-success-bg-subtle: #012317;
+    --bs-info-bg-subtle: #07272d;
+    --bs-warning-bg-subtle: #32230d;
+    --bs-danger-bg-subtle: #2f0e0e;
+
+    --bs-primary-border-subtle: #312c89;
+    --bs-secondary-border-subtle: #5c1e8b;
+    --bs-success-border-subtle: #036a44;
+    --bs-info-border-subtle: #167488;
+    --bs-warning-border-subtle: #966828;
+    --bs-danger-border-subtle: #8c2929;
+
+    --bs-link-color: #9792ef;
+    --bs-link-hover-color: #aca8f2;
+    --bs-link-color-rgb: 151, 146, 239;
+    --bs-link-hover-color-rgb: 172, 168, 242;
 }
 
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
+/* Override the smooth scrolling behavior */
+@media (prefers-reduced-motion: no-preference) {
+    :root {
+        /* Change to 'auto' for default instant scrolling */
+        scroll-behavior: auto !important;
+    }
 }
 
-body {
-  margin: 0;
-  font-family: var(--bs-body-font-family);
-  font-size: var(--bs-body-font-size);
-  font-weight: var(--bs-body-font-weight);
-  line-height: var(--bs-body-line-height);
-  color: var(--bs-body-color);
-  text-align: var(--bs-body-text-align);
-  background-color: var(--bs-body-bg);
-  -webkit-text-size-adjust: 100%;
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+h1,
+.h1 {
+    font-size: calc(1.34375rem + 1.125vw);
 }
 
-hr {
-  margin: 1rem 0;
-  color: inherit;
-  border: 0;
-  border-top: var(--bs-border-width) solid;
-  opacity: 0.25;
-}
-
-h6, .h6, h5, .h5, h4, .h4, h3, .h3, h2, .h2, h1, .h1 {
-  margin-top: 0;
-  margin-bottom: 0.5rem;
-  font-weight: 500;
-  line-height: 1.2;
-  color: var(--bs-heading-color);
-}
-
-h1, .h1 {
-  font-size: calc(1.34375rem + 1.125vw);
-}
 @media (min-width: 1200px) {
-  h1, .h1 {
-    font-size: 2.1875rem;
-  }
+
+    h1,
+    .h1 {
+        font-size: 2.1875rem;
+    }
 }
 
-h2, .h2 {
-  font-size: calc(1.3rem + 0.6vw);
+
+h2,
+.h2 {
+    font-size: calc(1.3rem + 0.6vw);
 }
+
 @media (min-width: 1200px) {
-  h2, .h2 {
-    font-size: 1.75rem;
-  }
+
+    h2,
+    .h2 {
+        font-size: 1.75rem;
+    }
 }
 
-h3, .h3 {
-  font-size: calc(1.278125rem + 0.3375vw);
+h3,
+.h3 {
+    font-size: calc(1.278125rem + 0.3375vw);
 }
+
 @media (min-width: 1200px) {
-  h3, .h3 {
-    font-size: 1.53125rem;
-  }
+
+    h3,
+    .h3 {
+        font-size: 1.53125rem;
+    }
 }
 
-h4, .h4 {
-  font-size: calc(1.25625rem + 0.075vw);
+h4,
+.h4 {
+    font-size: calc(1.25625rem + 0.075vw);
 }
+
 @media (min-width: 1200px) {
-  h4, .h4 {
-    font-size: 1.3125rem;
-  }
+
+    h4,
+    .h4 {
+        font-size: 1.3125rem;
+    }
 }
 
-h5, .h5 {
-  font-size: 1.09375rem;
+h5,
+.h5 {
+    font-size: 1.09375rem;
 }
 
-h6, .h6 {
-  font-size: 0.875rem;
+h6,
+.h6 {
+    font-size: 0.875rem;
 }
 
-p {
-  margin-top: 0;
-  margin-bottom: 1rem;
+small,
+.small,
+.chat-block .chat-content .messages .message-item.message-item-divider span {
+    font-size: 0.875em;
 }
 
-abbr[title] {
-  -webkit-text-decoration: underline dotted;
-          text-decoration: underline dotted;
-  cursor: help;
-  -webkit-text-decoration-skip-ink: none;
-          text-decoration-skip-ink: none;
-}
-
-address {
-  margin-bottom: 1rem;
-  font-style: normal;
-  line-height: inherit;
-}
-
-ol,
-ul {
-  padding-left: 2rem;
-}
-
-ol,
-ul,
-dl {
-  margin-top: 0;
-  margin-bottom: 1rem;
-}
-
-ol ol,
-ul ul,
-ol ul,
-ul ol {
-  margin-bottom: 0;
-}
-
-dt {
-  font-weight: 700;
-}
-
-dd {
-  margin-bottom: 0.5rem;
-  margin-left: 0;
-}
-
-blockquote {
-  margin: 0 0 1rem;
-}
-
-b,
-strong {
-  font-weight: bolder;
-}
-
-small, .small, .chat-block .chat-content .messages .message-item.message-item-divider span {
-  font-size: 0.875em;
-}
-
-mark, .mark {
-  padding: 0.1875em;
-  color: var(--bs-highlight-color);
-  background-color: var(--bs-highlight-bg);
-}
-
-sub,
-sup {
-  position: relative;
-  font-size: 0.75em;
-  line-height: 0;
-  vertical-align: baseline;
-}
-
-sub {
-  bottom: -0.25em;
-}
-
-sup {
-  top: -0.5em;
-}
-
-a {
-  color: rgba(var(--bs-link-color-rgb), var(--bs-link-opacity, 1));
-  text-decoration: underline;
-}
-a:hover {
-  --bs-link-color-rgb: var(--bs-link-hover-color-rgb);
-}
-
-a:not([href]):not([class]), a:not([href]):not([class]):hover {
-  color: inherit;
-  text-decoration: none;
-}
-
-pre,
-code,
-kbd,
-samp {
-  font-family: var(--bs-font-monospace);
-  font-size: 1em;
-}
-
-pre {
-  display: block;
-  margin-top: 0;
-  margin-bottom: 1rem;
-  overflow: auto;
-  font-size: 0.875em;
-}
-pre code {
-  font-size: inherit;
-  color: inherit;
-  word-break: normal;
-}
-
-code {
-  font-size: 0.875em;
-  color: var(--bs-code-color);
-  word-wrap: break-word;
-}
-a > code {
-  color: inherit;
-}
-
-kbd {
-  padding: 0.1875rem 0.375rem;
-  font-size: 0.875em;
-  color: var(--bs-body-bg);
-  background-color: var(--bs-body-color);
-  border-radius: 0.25rem;
-}
-kbd kbd {
-  padding: 0;
-  font-size: 1em;
-}
-
-figure {
-  margin: 0 0 1rem;
-}
-
-img,
-svg {
-  vertical-align: middle;
-}
-
-table {
-  caption-side: bottom;
-  border-collapse: collapse;
-}
-
-caption {
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-  color: var(--bs-secondary-color);
-  text-align: left;
-}
-
-th {
-  text-align: inherit;
-  text-align: -webkit-match-parent;
-}
-
-thead,
-tbody,
-tfoot,
-tr,
-td,
-th {
-  border-color: inherit;
-  border-style: solid;
-  border-width: 0;
-}
-
-label {
-  display: inline-block;
-}
-
-button {
-  border-radius: 0;
-}
-
-button:focus:not(:focus-visible) {
-  outline: 0;
-}
-
-input,
-button,
-select,
-optgroup,
-textarea {
-  margin: 0;
-  font-family: inherit;
-  font-size: inherit;
-  line-height: inherit;
-}
-
-button,
-select {
-  text-transform: none;
-}
-
-[role=button] {
-  cursor: pointer;
-}
-
-select {
-  word-wrap: normal;
-}
-select:disabled {
-  opacity: 1;
-}
-
-[list]:not([type=date]):not([type=datetime-local]):not([type=month]):not([type=week]):not([type=time])::-webkit-calendar-picker-indicator {
-  display: none !important;
-}
-
-button,
-[type=button],
-[type=reset],
-[type=submit] {
-  -webkit-appearance: button;
-}
-button:not(:disabled),
-[type=button]:not(:disabled),
-[type=reset]:not(:disabled),
-[type=submit]:not(:disabled) {
-  cursor: pointer;
-}
-
-::-moz-focus-inner {
-  padding: 0;
-  border-style: none;
-}
-
-textarea {
-  resize: vertical;
-}
-
-fieldset {
-  min-width: 0;
-  padding: 0;
-  margin: 0;
-  border: 0;
-}
-
-legend {
-  float: left;
-  width: 100%;
-  padding: 0;
-  margin-bottom: 0.5rem;
-  font-size: calc(1.275rem + 0.3vw);
-  line-height: inherit;
-}
-@media (min-width: 1200px) {
-  legend {
-    font-size: 1.5rem;
-  }
-}
-legend + * {
-  clear: left;
-}
-
-::-webkit-datetime-edit-fields-wrapper,
-::-webkit-datetime-edit-text,
-::-webkit-datetime-edit-minute,
-::-webkit-datetime-edit-hour-field,
-::-webkit-datetime-edit-day-field,
-::-webkit-datetime-edit-month-field,
-::-webkit-datetime-edit-year-field {
-  padding: 0;
-}
-
-::-webkit-inner-spin-button {
-  height: auto;
-}
-
-[type=search] {
-  -webkit-appearance: textfield;
-  outline-offset: -2px;
-}
-
-/* rtl:raw:
-[type="tel"],
-[type="url"],
-[type="email"],
-[type="number"] {
-  direction: ltr;
-}
-*/
-::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
-
-::-webkit-color-swatch-wrapper {
-  padding: 0;
-}
-
-::file-selector-button {
-  font: inherit;
-  -webkit-appearance: button;
-}
-
-output {
-  display: inline-block;
-}
-
-iframe {
-  border: 0;
-}
-
-summary {
-  display: list-item;
-  cursor: pointer;
-}
-
-progress {
-  vertical-align: baseline;
-}
-
-[hidden] {
-  display: none !important;
+/* Override the ::-webkit-file-upload-button styles to default */
+::-webkit-file-upload-button {
+    font: initial;
+    /* Reset font to initial value */
+    -webkit-appearance: initial;
+    /* Reset -webkit-appearance to initial value */
 }
 
 .lead {
-  font-size: 1.09375rem;
-  font-weight: 300;
+    font-size: 1.09375rem;
 }
 
 .display-1 {
-  font-size: calc(1.625rem + 4.5vw);
-  font-weight: 400;
-  line-height: 1.2;
-}
-@media (min-width: 1200px) {
-  .display-1 {
-    font-size: 5rem;
-  }
+    font-weight: 400;
 }
 
 .display-2 {
-  font-size: calc(1.575rem + 3.9vw);
-  font-weight: 400;
-  line-height: 1.2;
-}
-@media (min-width: 1200px) {
-  .display-2 {
-    font-size: 4.5rem;
-  }
+    font-weight: 400;
 }
 
 .display-3 {
-  font-size: calc(1.525rem + 3.3vw);
-  font-weight: 400;
-  line-height: 1.2;
-}
-@media (min-width: 1200px) {
-  .display-3 {
-    font-size: 4rem;
-  }
+    font-weight: 400;
 }
 
 .display-4 {
-  font-size: calc(1.475rem + 2.7vw);
-  font-weight: 400;
-  line-height: 1.2;
-}
-@media (min-width: 1200px) {
-  .display-4 {
-    font-size: 3.5rem;
-  }
+    font-weight: 400;
 }
 
 .display-5 {
-  font-size: calc(1.425rem + 2.1vw);
-  font-weight: 400;
-  line-height: 1.2;
-}
-@media (min-width: 1200px) {
-  .display-5 {
-    font-size: 3rem;
-  }
+    font-weight: 400;
 }
 
 .display-6 {
-  font-size: calc(1.375rem + 1.5vw);
-  font-weight: 400;
-  line-height: 1.2;
-}
-@media (min-width: 1200px) {
-  .display-6 {
-    font-size: 2.5rem;
-  }
+    font-weight: 400;
 }
 
 .display-7 {
-  font-size: calc(1.325rem + 0.9vw);
-  font-weight: 400;
-  line-height: 1.2;
+    font-size: calc(1.325rem + 0.9vw);
+    font-weight: 400;
+    line-height: 1.2;
 }
+
 @media (min-width: 1200px) {
-  .display-7 {
-    font-size: 2rem;
-  }
+    .display-7 {
+        font-size: 2rem;
+    }
 }
 
 .display-8 {
-  font-size: calc(1.305rem + 0.66vw);
-  font-weight: 400;
-  line-height: 1.2;
+    font-size: calc(1.305rem + 0.66vw);
+    font-weight: 400;
+    line-height: 1.2;
 }
+
 @media (min-width: 1200px) {
-  .display-8 {
-    font-size: 1.8rem;
-  }
-}
-
-.list-unstyled {
-  padding-left: 0;
-  list-style: none;
-}
-
-.list-inline {
-  padding-left: 0;
-  list-style: none;
-}
-
-.list-inline-item {
-  display: inline-block;
-}
-.list-inline-item:not(:last-child) {
-  margin-right: 0.5rem;
-}
-
-.initialism {
-  font-size: 0.875em;
-  text-transform: uppercase;
+    .display-8 {
+        font-size: 1.8rem;
+    }
 }
 
 .blockquote {
-  margin-bottom: 1rem;
-  font-size: 1.09375rem;
-}
-.blockquote > :last-child {
-  margin-bottom: 0;
+    font-size: 1.09375rem;
 }
 
-.blockquote-footer {
-  margin-top: -1rem;
-  margin-bottom: 1rem;
-  font-size: 0.875em;
-  color: #6c757d;
-}
-.blockquote-footer::before {
-  content: "— ";
-}
-
-.img-fluid {
-  max-width: 100%;
-  height: auto;
-}
-
-.img-thumbnail {
-  padding: 0.25rem;
-  background-color: var(--bs-body-bg);
-  border: var(--bs-border-width) solid var(--bs-border-color);
-  border-radius: var(--bs-border-radius);
-  max-width: 100%;
-  height: auto;
-}
-
-.figure {
-  display: inline-block;
-}
-
-.figure-img {
-  margin-bottom: 0.5rem;
-  line-height: 1;
-}
-
-.figure-caption {
-  font-size: 0.875em;
-  color: var(--bs-secondary-color);
-}
-
-.container,
-.container-fluid,
-.container-xxl,
-.container-xl,
-.container-lg,
-.container-md,
-.container-sm {
-  --bs-gutter-x: 1.5rem;
-  --bs-gutter-y: 0;
-  width: 100%;
-  padding-right: calc(var(--bs-gutter-x) * 0.5);
-  padding-left: calc(var(--bs-gutter-x) * 0.5);
-  margin-right: auto;
-  margin-left: auto;
-}
-
-@media (min-width: 576px) {
-  .container-sm, .container {
-    max-width: 540px;
-  }
-}
-@media (min-width: 768px) {
-  .container-md, .container-sm, .container {
-    max-width: 720px;
-  }
-}
-@media (min-width: 992px) {
-  .container-lg, .container-md, .container-sm, .container {
-    max-width: 960px;
-  }
-}
-@media (min-width: 1200px) {
-  .container-xl, .container-lg, .container-md, .container-sm, .container {
-    max-width: 1140px;
-  }
-}
-@media (min-width: 1400px) {
-  .container-xxl, .container-xl, .container-lg, .container-md, .container-sm, .container {
-    max-width: 1320px;
-  }
-}
-:root {
-  --bs-breakpoint-xs: 0;
-  --bs-breakpoint-sm: 576px;
-  --bs-breakpoint-md: 768px;
-  --bs-breakpoint-lg: 992px;
-  --bs-breakpoint-xl: 1200px;
-  --bs-breakpoint-xxl: 1400px;
-}
-
-.row {
-  --bs-gutter-x: 1.5rem;
-  --bs-gutter-y: 0;
-  display: flex;
-  flex-wrap: wrap;
-  margin-top: calc(-1 * var(--bs-gutter-y));
-  margin-right: calc(-0.5 * var(--bs-gutter-x));
-  margin-left: calc(-0.5 * var(--bs-gutter-x));
-}
-.row > * {
-  flex-shrink: 0;
-  width: 100%;
-  max-width: 100%;
-  padding-right: calc(var(--bs-gutter-x) * 0.5);
-  padding-left: calc(var(--bs-gutter-x) * 0.5);
-  margin-top: var(--bs-gutter-y);
-}
-
-.col {
-  flex: 1 0 0%;
-}
-
-.row-cols-auto > * {
-  flex: 0 0 auto;
-  width: auto;
-}
-
-.row-cols-1 > * {
-  flex: 0 0 auto;
-  width: 100%;
-}
-
-.row-cols-2 > * {
-  flex: 0 0 auto;
-  width: 50%;
-}
-
-.row-cols-3 > * {
-  flex: 0 0 auto;
-  width: 33.33333333%;
-}
-
-.row-cols-4 > * {
-  flex: 0 0 auto;
-  width: 25%;
-}
-
-.row-cols-5 > * {
-  flex: 0 0 auto;
-  width: 20%;
-}
-
-.row-cols-6 > * {
-  flex: 0 0 auto;
-  width: 16.66666667%;
-}
-
-.col-auto {
-  flex: 0 0 auto;
-  width: auto;
-}
-
-.col-1 {
-  flex: 0 0 auto;
-  width: 8.33333333%;
-}
-
-.col-2 {
-  flex: 0 0 auto;
-  width: 16.66666667%;
-}
-
-.col-3 {
-  flex: 0 0 auto;
-  width: 25%;
-}
-
-.col-4 {
-  flex: 0 0 auto;
-  width: 33.33333333%;
-}
-
-.col-5 {
-  flex: 0 0 auto;
-  width: 41.66666667%;
-}
-
-.col-6 {
-  flex: 0 0 auto;
-  width: 50%;
-}
-
-.col-7 {
-  flex: 0 0 auto;
-  width: 58.33333333%;
-}
-
-.col-8 {
-  flex: 0 0 auto;
-  width: 66.66666667%;
-}
-
-.col-9 {
-  flex: 0 0 auto;
-  width: 75%;
-}
-
-.col-10 {
-  flex: 0 0 auto;
-  width: 83.33333333%;
-}
-
-.col-11 {
-  flex: 0 0 auto;
-  width: 91.66666667%;
-}
-
-.col-12 {
-  flex: 0 0 auto;
-  width: 100%;
-}
-
-.offset-1 {
-  margin-left: 8.33333333%;
-}
-
-.offset-2 {
-  margin-left: 16.66666667%;
-}
-
-.offset-3 {
-  margin-left: 25%;
-}
-
-.offset-4 {
-  margin-left: 33.33333333%;
-}
-
-.offset-5 {
-  margin-left: 41.66666667%;
-}
-
-.offset-6 {
-  margin-left: 50%;
-}
-
-.offset-7 {
-  margin-left: 58.33333333%;
-}
-
-.offset-8 {
-  margin-left: 66.66666667%;
-}
-
-.offset-9 {
-  margin-left: 75%;
-}
-
-.offset-10 {
-  margin-left: 83.33333333%;
-}
-
-.offset-11 {
-  margin-left: 91.66666667%;
-}
-
-.g-0,
-.gx-0 {
-  --bs-gutter-x: 0;
-}
-
-.g-0,
-.gy-0 {
-  --bs-gutter-y: 0;
-}
-
-.g-1,
-.gx-1 {
-  --bs-gutter-x: 0.25rem;
-}
-
-.g-1,
-.gy-1 {
-  --bs-gutter-y: 0.25rem;
-}
-
-.g-2,
-.gx-2 {
-  --bs-gutter-x: 0.5rem;
-}
-
-.g-2,
-.gy-2 {
-  --bs-gutter-y: 0.5rem;
-}
-
-.g-3,
-.gx-3 {
-  --bs-gutter-x: 1rem;
-}
-
-.g-3,
-.gy-3 {
-  --bs-gutter-y: 1rem;
-}
-
-.g-4,
-.gx-4 {
-  --bs-gutter-x: 1.5rem;
-}
-
-.g-4,
-.gy-4 {
-  --bs-gutter-y: 1.5rem;
-}
-
-.g-5,
-.gx-5 {
-  --bs-gutter-x: 3rem;
-}
-
-.g-5,
-.gy-5 {
-  --bs-gutter-y: 3rem;
-}
-
-@media (min-width: 576px) {
-  .col-sm {
-    flex: 1 0 0%;
-  }
-  .row-cols-sm-auto > * {
-    flex: 0 0 auto;
-    width: auto;
-  }
-  .row-cols-sm-1 > * {
-    flex: 0 0 auto;
-    width: 100%;
-  }
-  .row-cols-sm-2 > * {
-    flex: 0 0 auto;
-    width: 50%;
-  }
-  .row-cols-sm-3 > * {
-    flex: 0 0 auto;
-    width: 33.33333333%;
-  }
-  .row-cols-sm-4 > * {
-    flex: 0 0 auto;
-    width: 25%;
-  }
-  .row-cols-sm-5 > * {
-    flex: 0 0 auto;
-    width: 20%;
-  }
-  .row-cols-sm-6 > * {
-    flex: 0 0 auto;
-    width: 16.66666667%;
-  }
-  .col-sm-auto {
-    flex: 0 0 auto;
-    width: auto;
-  }
-  .col-sm-1 {
-    flex: 0 0 auto;
-    width: 8.33333333%;
-  }
-  .col-sm-2 {
-    flex: 0 0 auto;
-    width: 16.66666667%;
-  }
-  .col-sm-3 {
-    flex: 0 0 auto;
-    width: 25%;
-  }
-  .col-sm-4 {
-    flex: 0 0 auto;
-    width: 33.33333333%;
-  }
-  .col-sm-5 {
-    flex: 0 0 auto;
-    width: 41.66666667%;
-  }
-  .col-sm-6 {
-    flex: 0 0 auto;
-    width: 50%;
-  }
-  .col-sm-7 {
-    flex: 0 0 auto;
-    width: 58.33333333%;
-  }
-  .col-sm-8 {
-    flex: 0 0 auto;
-    width: 66.66666667%;
-  }
-  .col-sm-9 {
-    flex: 0 0 auto;
-    width: 75%;
-  }
-  .col-sm-10 {
-    flex: 0 0 auto;
-    width: 83.33333333%;
-  }
-  .col-sm-11 {
-    flex: 0 0 auto;
-    width: 91.66666667%;
-  }
-  .col-sm-12 {
-    flex: 0 0 auto;
-    width: 100%;
-  }
-  .offset-sm-0 {
-    margin-left: 0;
-  }
-  .offset-sm-1 {
-    margin-left: 8.33333333%;
-  }
-  .offset-sm-2 {
-    margin-left: 16.66666667%;
-  }
-  .offset-sm-3 {
-    margin-left: 25%;
-  }
-  .offset-sm-4 {
-    margin-left: 33.33333333%;
-  }
-  .offset-sm-5 {
-    margin-left: 41.66666667%;
-  }
-  .offset-sm-6 {
-    margin-left: 50%;
-  }
-  .offset-sm-7 {
-    margin-left: 58.33333333%;
-  }
-  .offset-sm-8 {
-    margin-left: 66.66666667%;
-  }
-  .offset-sm-9 {
-    margin-left: 75%;
-  }
-  .offset-sm-10 {
-    margin-left: 83.33333333%;
-  }
-  .offset-sm-11 {
-    margin-left: 91.66666667%;
-  }
-  .g-sm-0,
-  .gx-sm-0 {
-    --bs-gutter-x: 0;
-  }
-  .g-sm-0,
-  .gy-sm-0 {
-    --bs-gutter-y: 0;
-  }
-  .g-sm-1,
-  .gx-sm-1 {
-    --bs-gutter-x: 0.25rem;
-  }
-  .g-sm-1,
-  .gy-sm-1 {
-    --bs-gutter-y: 0.25rem;
-  }
-  .g-sm-2,
-  .gx-sm-2 {
-    --bs-gutter-x: 0.5rem;
-  }
-  .g-sm-2,
-  .gy-sm-2 {
-    --bs-gutter-y: 0.5rem;
-  }
-  .g-sm-3,
-  .gx-sm-3 {
-    --bs-gutter-x: 1rem;
-  }
-  .g-sm-3,
-  .gy-sm-3 {
-    --bs-gutter-y: 1rem;
-  }
-  .g-sm-4,
-  .gx-sm-4 {
-    --bs-gutter-x: 1.5rem;
-  }
-  .g-sm-4,
-  .gy-sm-4 {
-    --bs-gutter-y: 1.5rem;
-  }
-  .g-sm-5,
-  .gx-sm-5 {
-    --bs-gutter-x: 3rem;
-  }
-  .g-sm-5,
-  .gy-sm-5 {
-    --bs-gutter-y: 3rem;
-  }
-}
-@media (min-width: 768px) {
-  .col-md {
-    flex: 1 0 0%;
-  }
-  .row-cols-md-auto > * {
-    flex: 0 0 auto;
-    width: auto;
-  }
-  .row-cols-md-1 > * {
-    flex: 0 0 auto;
-    width: 100%;
-  }
-  .row-cols-md-2 > * {
-    flex: 0 0 auto;
-    width: 50%;
-  }
-  .row-cols-md-3 > * {
-    flex: 0 0 auto;
-    width: 33.33333333%;
-  }
-  .row-cols-md-4 > * {
-    flex: 0 0 auto;
-    width: 25%;
-  }
-  .row-cols-md-5 > * {
-    flex: 0 0 auto;
-    width: 20%;
-  }
-  .row-cols-md-6 > * {
-    flex: 0 0 auto;
-    width: 16.66666667%;
-  }
-  .col-md-auto {
-    flex: 0 0 auto;
-    width: auto;
-  }
-  .col-md-1 {
-    flex: 0 0 auto;
-    width: 8.33333333%;
-  }
-  .col-md-2 {
-    flex: 0 0 auto;
-    width: 16.66666667%;
-  }
-  .col-md-3 {
-    flex: 0 0 auto;
-    width: 25%;
-  }
-  .col-md-4 {
-    flex: 0 0 auto;
-    width: 33.33333333%;
-  }
-  .col-md-5 {
-    flex: 0 0 auto;
-    width: 41.66666667%;
-  }
-  .col-md-6 {
-    flex: 0 0 auto;
-    width: 50%;
-  }
-  .col-md-7 {
-    flex: 0 0 auto;
-    width: 58.33333333%;
-  }
-  .col-md-8 {
-    flex: 0 0 auto;
-    width: 66.66666667%;
-  }
-  .col-md-9 {
-    flex: 0 0 auto;
-    width: 75%;
-  }
-  .col-md-10 {
-    flex: 0 0 auto;
-    width: 83.33333333%;
-  }
-  .col-md-11 {
-    flex: 0 0 auto;
-    width: 91.66666667%;
-  }
-  .col-md-12 {
-    flex: 0 0 auto;
-    width: 100%;
-  }
-  .offset-md-0 {
-    margin-left: 0;
-  }
-  .offset-md-1 {
-    margin-left: 8.33333333%;
-  }
-  .offset-md-2 {
-    margin-left: 16.66666667%;
-  }
-  .offset-md-3 {
-    margin-left: 25%;
-  }
-  .offset-md-4 {
-    margin-left: 33.33333333%;
-  }
-  .offset-md-5 {
-    margin-left: 41.66666667%;
-  }
-  .offset-md-6 {
-    margin-left: 50%;
-  }
-  .offset-md-7 {
-    margin-left: 58.33333333%;
-  }
-  .offset-md-8 {
-    margin-left: 66.66666667%;
-  }
-  .offset-md-9 {
-    margin-left: 75%;
-  }
-  .offset-md-10 {
-    margin-left: 83.33333333%;
-  }
-  .offset-md-11 {
-    margin-left: 91.66666667%;
-  }
-  .g-md-0,
-  .gx-md-0 {
-    --bs-gutter-x: 0;
-  }
-  .g-md-0,
-  .gy-md-0 {
-    --bs-gutter-y: 0;
-  }
-  .g-md-1,
-  .gx-md-1 {
-    --bs-gutter-x: 0.25rem;
-  }
-  .g-md-1,
-  .gy-md-1 {
-    --bs-gutter-y: 0.25rem;
-  }
-  .g-md-2,
-  .gx-md-2 {
-    --bs-gutter-x: 0.5rem;
-  }
-  .g-md-2,
-  .gy-md-2 {
-    --bs-gutter-y: 0.5rem;
-  }
-  .g-md-3,
-  .gx-md-3 {
-    --bs-gutter-x: 1rem;
-  }
-  .g-md-3,
-  .gy-md-3 {
-    --bs-gutter-y: 1rem;
-  }
-  .g-md-4,
-  .gx-md-4 {
-    --bs-gutter-x: 1.5rem;
-  }
-  .g-md-4,
-  .gy-md-4 {
-    --bs-gutter-y: 1.5rem;
-  }
-  .g-md-5,
-  .gx-md-5 {
-    --bs-gutter-x: 3rem;
-  }
-  .g-md-5,
-  .gy-md-5 {
-    --bs-gutter-y: 3rem;
-  }
-}
-@media (min-width: 992px) {
-  .col-lg {
-    flex: 1 0 0%;
-  }
-  .row-cols-lg-auto > * {
-    flex: 0 0 auto;
-    width: auto;
-  }
-  .row-cols-lg-1 > * {
-    flex: 0 0 auto;
-    width: 100%;
-  }
-  .row-cols-lg-2 > * {
-    flex: 0 0 auto;
-    width: 50%;
-  }
-  .row-cols-lg-3 > * {
-    flex: 0 0 auto;
-    width: 33.33333333%;
-  }
-  .row-cols-lg-4 > * {
-    flex: 0 0 auto;
-    width: 25%;
-  }
-  .row-cols-lg-5 > * {
-    flex: 0 0 auto;
-    width: 20%;
-  }
-  .row-cols-lg-6 > * {
-    flex: 0 0 auto;
-    width: 16.66666667%;
-  }
-  .col-lg-auto {
-    flex: 0 0 auto;
-    width: auto;
-  }
-  .col-lg-1 {
-    flex: 0 0 auto;
-    width: 8.33333333%;
-  }
-  .col-lg-2 {
-    flex: 0 0 auto;
-    width: 16.66666667%;
-  }
-  .col-lg-3 {
-    flex: 0 0 auto;
-    width: 25%;
-  }
-  .col-lg-4 {
-    flex: 0 0 auto;
-    width: 33.33333333%;
-  }
-  .col-lg-5 {
-    flex: 0 0 auto;
-    width: 41.66666667%;
-  }
-  .col-lg-6 {
-    flex: 0 0 auto;
-    width: 50%;
-  }
-  .col-lg-7 {
-    flex: 0 0 auto;
-    width: 58.33333333%;
-  }
-  .col-lg-8 {
-    flex: 0 0 auto;
-    width: 66.66666667%;
-  }
-  .col-lg-9 {
-    flex: 0 0 auto;
-    width: 75%;
-  }
-  .col-lg-10 {
-    flex: 0 0 auto;
-    width: 83.33333333%;
-  }
-  .col-lg-11 {
-    flex: 0 0 auto;
-    width: 91.66666667%;
-  }
-  .col-lg-12 {
-    flex: 0 0 auto;
-    width: 100%;
-  }
-  .offset-lg-0 {
-    margin-left: 0;
-  }
-  .offset-lg-1 {
-    margin-left: 8.33333333%;
-  }
-  .offset-lg-2 {
-    margin-left: 16.66666667%;
-  }
-  .offset-lg-3 {
-    margin-left: 25%;
-  }
-  .offset-lg-4 {
-    margin-left: 33.33333333%;
-  }
-  .offset-lg-5 {
-    margin-left: 41.66666667%;
-  }
-  .offset-lg-6 {
-    margin-left: 50%;
-  }
-  .offset-lg-7 {
-    margin-left: 58.33333333%;
-  }
-  .offset-lg-8 {
-    margin-left: 66.66666667%;
-  }
-  .offset-lg-9 {
-    margin-left: 75%;
-  }
-  .offset-lg-10 {
-    margin-left: 83.33333333%;
-  }
-  .offset-lg-11 {
-    margin-left: 91.66666667%;
-  }
-  .g-lg-0,
-  .gx-lg-0 {
-    --bs-gutter-x: 0;
-  }
-  .g-lg-0,
-  .gy-lg-0 {
-    --bs-gutter-y: 0;
-  }
-  .g-lg-1,
-  .gx-lg-1 {
-    --bs-gutter-x: 0.25rem;
-  }
-  .g-lg-1,
-  .gy-lg-1 {
-    --bs-gutter-y: 0.25rem;
-  }
-  .g-lg-2,
-  .gx-lg-2 {
-    --bs-gutter-x: 0.5rem;
-  }
-  .g-lg-2,
-  .gy-lg-2 {
-    --bs-gutter-y: 0.5rem;
-  }
-  .g-lg-3,
-  .gx-lg-3 {
-    --bs-gutter-x: 1rem;
-  }
-  .g-lg-3,
-  .gy-lg-3 {
-    --bs-gutter-y: 1rem;
-  }
-  .g-lg-4,
-  .gx-lg-4 {
-    --bs-gutter-x: 1.5rem;
-  }
-  .g-lg-4,
-  .gy-lg-4 {
-    --bs-gutter-y: 1.5rem;
-  }
-  .g-lg-5,
-  .gx-lg-5 {
-    --bs-gutter-x: 3rem;
-  }
-  .g-lg-5,
-  .gy-lg-5 {
-    --bs-gutter-y: 3rem;
-  }
-}
-@media (min-width: 1200px) {
-  .col-xl {
-    flex: 1 0 0%;
-  }
-  .row-cols-xl-auto > * {
-    flex: 0 0 auto;
-    width: auto;
-  }
-  .row-cols-xl-1 > * {
-    flex: 0 0 auto;
-    width: 100%;
-  }
-  .row-cols-xl-2 > * {
-    flex: 0 0 auto;
-    width: 50%;
-  }
-  .row-cols-xl-3 > * {
-    flex: 0 0 auto;
-    width: 33.33333333%;
-  }
-  .row-cols-xl-4 > * {
-    flex: 0 0 auto;
-    width: 25%;
-  }
-  .row-cols-xl-5 > * {
-    flex: 0 0 auto;
-    width: 20%;
-  }
-  .row-cols-xl-6 > * {
-    flex: 0 0 auto;
-    width: 16.66666667%;
-  }
-  .col-xl-auto {
-    flex: 0 0 auto;
-    width: auto;
-  }
-  .col-xl-1 {
-    flex: 0 0 auto;
-    width: 8.33333333%;
-  }
-  .col-xl-2 {
-    flex: 0 0 auto;
-    width: 16.66666667%;
-  }
-  .col-xl-3 {
-    flex: 0 0 auto;
-    width: 25%;
-  }
-  .col-xl-4 {
-    flex: 0 0 auto;
-    width: 33.33333333%;
-  }
-  .col-xl-5 {
-    flex: 0 0 auto;
-    width: 41.66666667%;
-  }
-  .col-xl-6 {
-    flex: 0 0 auto;
-    width: 50%;
-  }
-  .col-xl-7 {
-    flex: 0 0 auto;
-    width: 58.33333333%;
-  }
-  .col-xl-8 {
-    flex: 0 0 auto;
-    width: 66.66666667%;
-  }
-  .col-xl-9 {
-    flex: 0 0 auto;
-    width: 75%;
-  }
-  .col-xl-10 {
-    flex: 0 0 auto;
-    width: 83.33333333%;
-  }
-  .col-xl-11 {
-    flex: 0 0 auto;
-    width: 91.66666667%;
-  }
-  .col-xl-12 {
-    flex: 0 0 auto;
-    width: 100%;
-  }
-  .offset-xl-0 {
-    margin-left: 0;
-  }
-  .offset-xl-1 {
-    margin-left: 8.33333333%;
-  }
-  .offset-xl-2 {
-    margin-left: 16.66666667%;
-  }
-  .offset-xl-3 {
-    margin-left: 25%;
-  }
-  .offset-xl-4 {
-    margin-left: 33.33333333%;
-  }
-  .offset-xl-5 {
-    margin-left: 41.66666667%;
-  }
-  .offset-xl-6 {
-    margin-left: 50%;
-  }
-  .offset-xl-7 {
-    margin-left: 58.33333333%;
-  }
-  .offset-xl-8 {
-    margin-left: 66.66666667%;
-  }
-  .offset-xl-9 {
-    margin-left: 75%;
-  }
-  .offset-xl-10 {
-    margin-left: 83.33333333%;
-  }
-  .offset-xl-11 {
-    margin-left: 91.66666667%;
-  }
-  .g-xl-0,
-  .gx-xl-0 {
-    --bs-gutter-x: 0;
-  }
-  .g-xl-0,
-  .gy-xl-0 {
-    --bs-gutter-y: 0;
-  }
-  .g-xl-1,
-  .gx-xl-1 {
-    --bs-gutter-x: 0.25rem;
-  }
-  .g-xl-1,
-  .gy-xl-1 {
-    --bs-gutter-y: 0.25rem;
-  }
-  .g-xl-2,
-  .gx-xl-2 {
-    --bs-gutter-x: 0.5rem;
-  }
-  .g-xl-2,
-  .gy-xl-2 {
-    --bs-gutter-y: 0.5rem;
-  }
-  .g-xl-3,
-  .gx-xl-3 {
-    --bs-gutter-x: 1rem;
-  }
-  .g-xl-3,
-  .gy-xl-3 {
-    --bs-gutter-y: 1rem;
-  }
-  .g-xl-4,
-  .gx-xl-4 {
-    --bs-gutter-x: 1.5rem;
-  }
-  .g-xl-4,
-  .gy-xl-4 {
-    --bs-gutter-y: 1.5rem;
-  }
-  .g-xl-5,
-  .gx-xl-5 {
-    --bs-gutter-x: 3rem;
-  }
-  .g-xl-5,
-  .gy-xl-5 {
-    --bs-gutter-y: 3rem;
-  }
-}
-@media (min-width: 1400px) {
-  .col-xxl {
-    flex: 1 0 0%;
-  }
-  .row-cols-xxl-auto > * {
-    flex: 0 0 auto;
-    width: auto;
-  }
-  .row-cols-xxl-1 > * {
-    flex: 0 0 auto;
-    width: 100%;
-  }
-  .row-cols-xxl-2 > * {
-    flex: 0 0 auto;
-    width: 50%;
-  }
-  .row-cols-xxl-3 > * {
-    flex: 0 0 auto;
-    width: 33.33333333%;
-  }
-  .row-cols-xxl-4 > * {
-    flex: 0 0 auto;
-    width: 25%;
-  }
-  .row-cols-xxl-5 > * {
-    flex: 0 0 auto;
-    width: 20%;
-  }
-  .row-cols-xxl-6 > * {
-    flex: 0 0 auto;
-    width: 16.66666667%;
-  }
-  .col-xxl-auto {
-    flex: 0 0 auto;
-    width: auto;
-  }
-  .col-xxl-1 {
-    flex: 0 0 auto;
-    width: 8.33333333%;
-  }
-  .col-xxl-2 {
-    flex: 0 0 auto;
-    width: 16.66666667%;
-  }
-  .col-xxl-3 {
-    flex: 0 0 auto;
-    width: 25%;
-  }
-  .col-xxl-4 {
-    flex: 0 0 auto;
-    width: 33.33333333%;
-  }
-  .col-xxl-5 {
-    flex: 0 0 auto;
-    width: 41.66666667%;
-  }
-  .col-xxl-6 {
-    flex: 0 0 auto;
-    width: 50%;
-  }
-  .col-xxl-7 {
-    flex: 0 0 auto;
-    width: 58.33333333%;
-  }
-  .col-xxl-8 {
-    flex: 0 0 auto;
-    width: 66.66666667%;
-  }
-  .col-xxl-9 {
-    flex: 0 0 auto;
-    width: 75%;
-  }
-  .col-xxl-10 {
-    flex: 0 0 auto;
-    width: 83.33333333%;
-  }
-  .col-xxl-11 {
-    flex: 0 0 auto;
-    width: 91.66666667%;
-  }
-  .col-xxl-12 {
-    flex: 0 0 auto;
-    width: 100%;
-  }
-  .offset-xxl-0 {
-    margin-left: 0;
-  }
-  .offset-xxl-1 {
-    margin-left: 8.33333333%;
-  }
-  .offset-xxl-2 {
-    margin-left: 16.66666667%;
-  }
-  .offset-xxl-3 {
-    margin-left: 25%;
-  }
-  .offset-xxl-4 {
-    margin-left: 33.33333333%;
-  }
-  .offset-xxl-5 {
-    margin-left: 41.66666667%;
-  }
-  .offset-xxl-6 {
-    margin-left: 50%;
-  }
-  .offset-xxl-7 {
-    margin-left: 58.33333333%;
-  }
-  .offset-xxl-8 {
-    margin-left: 66.66666667%;
-  }
-  .offset-xxl-9 {
-    margin-left: 75%;
-  }
-  .offset-xxl-10 {
-    margin-left: 83.33333333%;
-  }
-  .offset-xxl-11 {
-    margin-left: 91.66666667%;
-  }
-  .g-xxl-0,
-  .gx-xxl-0 {
-    --bs-gutter-x: 0;
-  }
-  .g-xxl-0,
-  .gy-xxl-0 {
-    --bs-gutter-y: 0;
-  }
-  .g-xxl-1,
-  .gx-xxl-1 {
-    --bs-gutter-x: 0.25rem;
-  }
-  .g-xxl-1,
-  .gy-xxl-1 {
-    --bs-gutter-y: 0.25rem;
-  }
-  .g-xxl-2,
-  .gx-xxl-2 {
-    --bs-gutter-x: 0.5rem;
-  }
-  .g-xxl-2,
-  .gy-xxl-2 {
-    --bs-gutter-y: 0.5rem;
-  }
-  .g-xxl-3,
-  .gx-xxl-3 {
-    --bs-gutter-x: 1rem;
-  }
-  .g-xxl-3,
-  .gy-xxl-3 {
-    --bs-gutter-y: 1rem;
-  }
-  .g-xxl-4,
-  .gx-xxl-4 {
-    --bs-gutter-x: 1.5rem;
-  }
-  .g-xxl-4,
-  .gy-xxl-4 {
-    --bs-gutter-y: 1.5rem;
-  }
-  .g-xxl-5,
-  .gx-xxl-5 {
-    --bs-gutter-x: 3rem;
-  }
-  .g-xxl-5,
-  .gy-xxl-5 {
-    --bs-gutter-y: 3rem;
-  }
-}
-.table {
-  --bs-table-color-type: initial;
-  --bs-table-bg-type: initial;
-  --bs-table-color-state: initial;
-  --bs-table-bg-state: initial;
-  --bs-table-color: var(--bs-emphasis-color);
-  --bs-table-bg: var(--bs-body-bg);
-  --bs-table-border-color: var(--bs-border-color);
-  --bs-table-accent-bg: transparent;
-  --bs-table-striped-color: var(--bs-emphasis-color);
-  --bs-table-striped-bg: rgba(var(--bs-emphasis-color-rgb), 0.05);
-  --bs-table-active-color: var(--bs-emphasis-color);
-  --bs-table-active-bg: rgba(var(--bs-emphasis-color-rgb), 0.1);
-  --bs-table-hover-color: var(--bs-emphasis-color);
-  --bs-table-hover-bg: rgba(var(--bs-emphasis-color-rgb), 0.075);
-  width: 100%;
-  margin-bottom: 1rem;
-  vertical-align: top;
-  border-color: var(--bs-table-border-color);
-}
-.table > :not(caption) > * > * {
-  padding: 0.5rem 0.5rem;
-  color: var(--bs-table-color-state, var(--bs-table-color-type, var(--bs-table-color)));
-  background-color: var(--bs-table-bg);
-  border-bottom-width: var(--bs-border-width);
-  box-shadow: inset 0 0 0 9999px var(--bs-table-bg-state, var(--bs-table-bg-type, var(--bs-table-accent-bg)));
-}
-.table > tbody {
-  vertical-align: inherit;
-}
-.table > thead {
-  vertical-align: bottom;
-}
-
-.table-group-divider {
-  border-top: calc(var(--bs-border-width) * 2) solid currentcolor;
-}
-
-.caption-top {
-  caption-side: top;
-}
-
-.table-sm > :not(caption) > * > * {
-  padding: 0.25rem 0.25rem;
-}
-
-.table-bordered > :not(caption) > * {
-  border-width: var(--bs-border-width) 0;
-}
-.table-bordered > :not(caption) > * > * {
-  border-width: 0 var(--bs-border-width);
-}
-
-.table-borderless > :not(caption) > * > * {
-  border-bottom-width: 0;
-}
-.table-borderless > :not(:first-child) {
-  border-top-width: 0;
-}
-
-.table-striped > tbody > tr:nth-of-type(odd) > * {
-  --bs-table-color-type: var(--bs-table-striped-color);
-  --bs-table-bg-type: var(--bs-table-striped-bg);
-}
-
-.table-striped-columns > :not(caption) > tr > :nth-child(even) {
-  --bs-table-color-type: var(--bs-table-striped-color);
-  --bs-table-bg-type: var(--bs-table-striped-bg);
-}
-
-.table-active {
-  --bs-table-color-state: var(--bs-table-active-color);
-  --bs-table-bg-state: var(--bs-table-active-bg);
-}
-
-.table-hover > tbody > tr:hover > * {
-  --bs-table-color-state: var(--bs-table-hover-color);
-  --bs-table-bg-state: var(--bs-table-hover-bg);
-}
 
 .table-primary {
-  --bs-table-color: #000;
-  --bs-table-bg: #dcdbfa;
-  --bs-table-border-color: #b0afc8;
-  --bs-table-striped-bg: #d1d0ee;
-  --bs-table-striped-color: #000;
-  --bs-table-active-bg: #c6c5e1;
-  --bs-table-active-color: #000;
-  --bs-table-hover-bg: #cccbe7;
-  --bs-table-hover-color: #000;
-  color: var(--bs-table-color);
-  border-color: var(--bs-table-border-color);
+    --bs-table-bg: #dcdbfa;
+    --bs-table-border-color: #b0afc8;
+    --bs-table-striped-bg: #d1d0ee;
+    --bs-table-active-bg: #c6c5e1;
+    --bs-table-hover-bg: #cccbe7;
+    border-color: var(--bs-table-border-color);
 }
 
 .table-secondary {
-  --bs-table-color: #000;
-  --bs-table-bg: #ebd6fa;
-  --bs-table-border-color: #bcabc8;
-  --bs-table-striped-bg: #dfcbee;
-  --bs-table-striped-color: #000;
-  --bs-table-active-bg: #d4c1e1;
-  --bs-table-active-color: #000;
-  --bs-table-hover-bg: #d9c6e7;
-  --bs-table-hover-color: #000;
-  color: var(--bs-table-color);
-  border-color: var(--bs-table-border-color);
+    --bs-table-bg: #ebd6fa;
+    --bs-table-border-color: #bcabc8;
+    --bs-table-striped-bg: #dfcbee;
+    --bs-table-active-bg: #d4c1e1;
+    --bs-table-hover-bg: #d9c6e7;
+    border-color: var(--bs-table-border-color);
 }
 
 .table-success {
-  --bs-table-color: #000;
-  --bs-table-bg: #cdefe3;
-  --bs-table-border-color: #a4bfb6;
-  --bs-table-striped-bg: #c3e3d8;
-  --bs-table-striped-color: #000;
-  --bs-table-active-bg: #b9d7cc;
-  --bs-table-active-color: #000;
-  --bs-table-hover-bg: #beddd2;
-  --bs-table-hover-color: #000;
-  color: var(--bs-table-color);
-  border-color: var(--bs-table-border-color);
+    --bs-table-bg: #cdefe3;
+    --bs-table-border-color: #a4bfb6;
+    --bs-table-striped-bg: #c3e3d8;
+    --bs-table-active-bg: #b9d7cc;
+    --bs-table-hover-bg: #beddd2;
+    border-color: var(--bs-table-border-color);
 }
 
 .table-info {
-  --bs-table-color: #000;
-  --bs-table-bg: #d3f3f9;
-  --bs-table-border-color: #a9c2c7;
-  --bs-table-striped-bg: #c8e7ed;
-  --bs-table-striped-color: #000;
-  --bs-table-active-bg: #bedbe0;
-  --bs-table-active-color: #000;
-  --bs-table-hover-bg: #c3e1e6;
-  --bs-table-hover-color: #000;
-  color: var(--bs-table-color);
-  border-color: var(--bs-table-border-color);
+    --bs-table-bg: #d3f3f9;
+    --bs-table-border-color: #a9c2c7;
+    --bs-table-striped-bg: #c8e7ed;
+    --bs-table-active-bg: #bedbe0;
+    --bs-table-hover-bg: #c3e1e6;
+    border-color: var(--bs-table-border-color);
 }
 
 .table-warning {
-  --bs-table-color: #000;
-  --bs-table-bg: #feefd9;
-  --bs-table-border-color: #cbbfae;
-  --bs-table-striped-bg: #f1e3ce;
-  --bs-table-striped-color: #000;
-  --bs-table-active-bg: #e5d7c3;
-  --bs-table-active-color: #000;
-  --bs-table-hover-bg: #ebddc9;
-  --bs-table-hover-color: #000;
-  color: var(--bs-table-color);
-  border-color: var(--bs-table-border-color);
+    --bs-table-bg: #feefd9;
+    --bs-table-border-color: #cbbfae;
+    --bs-table-striped-bg: #f1e3ce;
+    --bs-table-active-bg: #e5d7c3;
+    --bs-table-hover-bg: #ebddc9;
+    border-color: var(--bs-table-border-color);
 }
 
 .table-danger {
-  --bs-table-color: #000;
-  --bs-table-bg: #fbdada;
-  --bs-table-border-color: #c9aeae;
-  --bs-table-striped-bg: #eecfcf;
-  --bs-table-striped-color: #000;
-  --bs-table-active-bg: #e2c4c4;
-  --bs-table-active-color: #000;
-  --bs-table-hover-bg: #e8caca;
-  --bs-table-hover-color: #000;
-  color: var(--bs-table-color);
-  border-color: var(--bs-table-border-color);
+    --bs-table-bg: #fbdada;
+    --bs-table-border-color: #c9aeae;
+    --bs-table-striped-bg: #eecfcf;
+    --bs-table-active-bg: #e2c4c4;
+    --bs-table-hover-bg: #e8caca;
+    border-color: var(--bs-table-border-color);
 }
 
 .table-light {
-  --bs-table-color: #000;
-  --bs-table-bg: #ededed;
-  --bs-table-border-color: #bebebe;
-  --bs-table-striped-bg: #e1e1e1;
-  --bs-table-striped-color: #000;
-  --bs-table-active-bg: #d5d5d5;
-  --bs-table-active-color: #000;
-  --bs-table-hover-bg: #dbdbdb;
-  --bs-table-hover-color: #000;
-  color: var(--bs-table-color);
-  border-color: var(--bs-table-border-color);
+    --bs-table-bg: #ededed;
+    --bs-table-border-color: #bebebe;
+    --bs-table-striped-bg: #e1e1e1;
+    --bs-table-active-bg: #d5d5d5;
+    --bs-table-hover-bg: #dbdbdb;
+    border-color: var(--bs-table-border-color);
 }
 
 .table-dark {
-  --bs-table-color: #fff;
-  --bs-table-bg: #293134;
-  --bs-table-border-color: #545a5d;
-  --bs-table-striped-bg: #343b3e;
-  --bs-table-striped-color: #fff;
-  --bs-table-active-bg: #3e4648;
-  --bs-table-active-color: #fff;
-  --bs-table-hover-bg: #394043;
-  --bs-table-hover-color: #fff;
-  color: var(--bs-table-color);
-  border-color: var(--bs-table-border-color);
-}
-
-.table-responsive {
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-}
-
-@media (max-width: 575.98px) {
-  .table-responsive-sm {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-  }
-}
-@media (max-width: 767.98px) {
-  .table-responsive-md {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-  }
-}
-@media (max-width: 991.98px) {
-  .table-responsive-lg {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-  }
-}
-@media (max-width: 1199.98px) {
-  .table-responsive-xl {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-  }
-}
-@media (max-width: 1399.98px) {
-  .table-responsive-xxl {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-  }
-}
-.form-label {
-  margin-bottom: 0.5rem;
+    --bs-table-bg: #293134;
+    --bs-table-border-color: #545a5d;
+    --bs-table-striped-bg: #343b3e;
+    --bs-table-active-bg: #3e4648;
+    --bs-table-hover-bg: #394043;
+    border-color: var(--bs-table-border-color);
 }
 
 .col-form-label {
-  padding-top: calc(0.675rem + var(--bs-border-width));
-  padding-bottom: calc(0.675rem + var(--bs-border-width));
-  margin-bottom: 0;
-  font-size: inherit;
-  line-height: 1.5;
+    padding-top: calc(0.675rem + var(--bs-border-width));
+    padding-bottom: calc(0.675rem + var(--bs-border-width));
 }
 
 .col-form-label-lg {
-  padding-top: calc(1rem + var(--bs-border-width));
-  padding-bottom: calc(1rem + var(--bs-border-width));
-  font-size: 1.09375rem;
+    padding-top: calc(1rem + var(--bs-border-width));
+    padding-bottom: calc(1rem + var(--bs-border-width));
+    font-size: 1.09375rem;
 }
 
 .col-form-label-sm {
-  padding-top: calc(0.25rem + var(--bs-border-width));
-  padding-bottom: calc(0.25rem + var(--bs-border-width));
-  font-size: 0.765625rem;
+    font-size: 0.765625rem;
 }
 
-.form-text {
-  margin-top: 0.25rem;
-  font-size: 0.875em;
-  color: var(--bs-secondary-color);
+.form-control,
+.swal2-modal .swal2-input {
+    display: block;
+    width: 100%;
+    padding: 0.675rem 1.25rem;
+    font-size: 0.875rem;
+    font-weight: 400;
+    line-height: 1.5;
+    color: var(--bs-body-color);
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background-color: var(--bs-body-bg);
+    background-clip: padding-box;
+    border: var(--bs-border-width) solid var(--bs-border-color);
+    border-radius: var(--bs-border-radius);
+    transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
 
-.form-control, .swal2-modal .swal2-input {
-  display: block;
-  width: 100%;
-  padding: 0.675rem 1.25rem;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.5;
-  color: var(--bs-body-color);
-  -webkit-appearance: none;
-     -moz-appearance: none;
-          appearance: none;
-  background-color: var(--bs-body-bg);
-  background-clip: padding-box;
-  border: var(--bs-border-width) solid var(--bs-border-color);
-  border-radius: var(--bs-border-radius);
-  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-}
 @media (prefers-reduced-motion: reduce) {
-  .form-control, .swal2-modal .swal2-input {
-    transition: none;
-  }
+
+    .form-control,
+    .swal2-modal .swal2-input {
+        transition: none;
+    }
 }
-.form-control[type=file], .swal2-modal [type=file].swal2-input {
-  overflow: hidden;
+
+.form-control[type=file],
+.swal2-modal [type=file].swal2-input {
+    overflow: hidden;
 }
-.form-control[type=file]:not(:disabled):not([readonly]), .swal2-modal [type=file].swal2-input:not(:disabled):not([readonly]) {
-  cursor: pointer;
+
+.form-control[type=file]:not(:disabled):not([readonly]),
+.swal2-modal [type=file].swal2-input:not(:disabled):not([readonly]) {
+    cursor: pointer;
 }
-.form-control:focus, .swal2-modal .swal2-input:focus {
-  color: var(--bs-body-color);
-  background-color: var(--bs-body-bg);
-  border-color: #a8a4f2;
-  outline: 0;
-  box-shadow: 0 0 0 1px #5149e5;
+
+.form-control:focus,
+.swal2-modal .swal2-input:focus {
+    color: var(--bs-body-color);
+    background-color: var(--bs-body-bg);
+    border-color: #a8a4f2;
+    outline: 0;
+    box-shadow: 0 0 0 1px #5149e5;
 }
-.form-control::-webkit-date-and-time-value, .swal2-modal .swal2-input::-webkit-date-and-time-value {
-  min-width: 85px;
-  height: 1.5em;
-  margin: 0;
+
+.form-control::-webkit-date-and-time-value,
+.swal2-modal .swal2-input::-webkit-date-and-time-value {
+    min-width: 85px;
+    height: 1.5em;
+    margin: 0;
 }
-.form-control::-webkit-datetime-edit, .swal2-modal .swal2-input::-webkit-datetime-edit {
-  display: block;
-  padding: 0;
+
+.form-control::-webkit-datetime-edit,
+.swal2-modal .swal2-input::-webkit-datetime-edit {
+    display: block;
+    padding: 0;
 }
-.form-control::-moz-placeholder, .swal2-modal .swal2-input::-moz-placeholder {
-  color: var(--bs-secondary-color);
-  opacity: 1;
+
+.form-control::-moz-placeholder,
+.swal2-modal .swal2-input::-moz-placeholder {
+    color: var(--bs-secondary-color);
+    opacity: 1;
 }
-.form-control::placeholder, .swal2-modal .swal2-input::placeholder {
-  color: var(--bs-secondary-color);
-  opacity: 1;
+
+.form-control::placeholder,
+.swal2-modal .swal2-input::placeholder {
+    color: var(--bs-secondary-color);
+    opacity: 1;
 }
-.form-control:disabled, .swal2-modal .swal2-input:disabled {
-  background-color: var(--bs-secondary-bg);
-  opacity: 1;
+
+.form-control:disabled,
+.swal2-modal .swal2-input:disabled {
+    background-color: var(--bs-secondary-bg);
+    opacity: 1;
 }
-.form-control::file-selector-button, .swal2-modal .swal2-input::file-selector-button {
-  padding: 0.675rem 1.25rem;
-  margin: -0.675rem -1.25rem;
-  margin-inline-end: 1.25rem;
-  color: var(--bs-body-color);
-  background-color: var(--bs-tertiary-bg);
-  pointer-events: none;
-  border-color: inherit;
-  border-style: solid;
-  border-width: 0;
-  border-inline-end-width: var(--bs-border-width);
-  border-radius: 0;
-  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+
+.form-control::file-selector-button,
+.swal2-modal .swal2-input::file-selector-button {
+    padding: 0.675rem 1.25rem;
+    margin: -0.675rem -1.25rem;
+    margin-inline-end: 1.25rem;
+    color: var(--bs-body-color);
+    background-color: var(--bs-tertiary-bg);
+    pointer-events: none;
+    border-color: inherit;
+    border-style: solid;
+    border-width: 0;
+    border-inline-end-width: var(--bs-border-width);
+    border-radius: 0;
+    transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
+
+
 @media (prefers-reduced-motion: reduce) {
-  .form-control::file-selector-button, .swal2-modal .swal2-input::file-selector-button {
-    transition: none;
-  }
+
+    /* Reverting reduced motion styles for file upload buttons */
+    .form-control::-webkit-file-upload-button {
+        -webkit-transition: initial;
+        /* Reset -webkit-transition to initial value */
+        transition: initial;
+        /* Reset transition to initial value */
+    }
+
+    .form-control::file-selector-button,
+    .swal2-modal .swal2-input::file-selector-button {
+        transition: none;
+    }
 }
-.form-control:hover:not(:disabled):not([readonly])::file-selector-button, .swal2-modal .swal2-input:hover:not(:disabled):not([readonly])::file-selector-button {
-  background-color: var(--bs-secondary-bg);
+
+.form-control:hover:not(:disabled):not([readonly])::file-selector-button,
+.swal2-modal .swal2-input:hover:not(:disabled):not([readonly])::file-selector-button {
+    background-color: var(--bs-secondary-bg);
 }
 
 .form-control-plaintext {
-  display: block;
-  width: 100%;
-  padding: 0.675rem 0;
-  margin-bottom: 0;
-  line-height: 1.5;
-  color: var(--bs-body-color);
-  background-color: transparent;
-  border: solid transparent;
-  border-width: var(--bs-border-width) 0;
-}
-.form-control-plaintext:focus {
-  outline: 0;
-}
-.form-control-plaintext.form-control-sm, .form-control-plaintext.form-control-lg {
-  padding-right: 0;
-  padding-left: 0;
+    padding: 0.675rem 0;
 }
 
 .form-control-sm {
-  min-height: calc(1.5em + 0.5rem + calc(var(--bs-border-width) * 2));
-  padding: 0.25rem 0.5rem;
-  font-size: 0.765625rem;
-  border-radius: var(--bs-border-radius-sm);
+    font-size: 0.765625rem;
 }
+
+/* Resetting styles for .form-control-sm::-webkit-file-upload-button */
+.form-control-sm::-webkit-file-upload-button {
+    padding: initial;
+    /* Reset padding to initial value */
+    margin: initial;
+    /* Reset margin to initial value */
+    -webkit-margin-end: initial;
+    /* Reset -webkit-margin-end to initial value */
+    margin-inline-end: initial;
+    /* Reset margin-inline-end to initial value */
+    /* Or alternatively, you can use 'unset' */
+    /* padding: unset; */
+    /* margin: unset; */
+    /* -webkit-margin-end: unset; */
+    /* margin-inline-end: unset; */
+}
+
+/* Resetting -webkit-margin-end for .form-control-sm::file-selector-button */
 .form-control-sm::file-selector-button {
-  padding: 0.25rem 0.5rem;
-  margin: -0.25rem -0.5rem;
-  margin-inline-end: 0.5rem;
+    -webkit-margin-end: initial;
+    /* Reset -webkit-margin-end to its default value */
 }
 
 .form-control-lg {
-  min-height: calc(1.5em + 2rem + calc(var(--bs-border-width) * 2));
-  padding: 1rem 1.5rem;
-  font-size: 1.09375rem;
-  border-radius: var(--bs-border-radius-lg);
-}
-.form-control-lg::file-selector-button {
-  padding: 1rem 1.5rem;
-  margin: -1rem -1.5rem;
-  margin-inline-end: 1.5rem;
+    min-height: calc(1.5em + 2rem + calc(var(--bs-border-width) * 2));
+    padding: 1rem 1.5rem;
+    font-size: 1.09375rem;
+    border-radius: var(--bs-border-radius-lg);
 }
 
-textarea.form-control, .swal2-modal textarea.swal2-input {
-  min-height: calc(1.5em + 1.35rem + calc(var(--bs-border-width) * 2));
+/* Resetting styles for .form-control-lg::-webkit-file-upload-button */
+.form-control-lg::-webkit-file-upload-button {
+    padding: initial;
+    /* Reset padding to initial value */
+    margin: initial;
+    /* Reset margin to initial value */
+    -webkit-margin-end: initial;
+    /* Reset -webkit-margin-end to initial value */
+    margin-inline-end: initial;
+    /* Reset margin-inline-end to initial value */
+    /* Alternatively, you can use 'unset' */
+    /* padding: unset; */
+    /* margin: unset; */
+    /* -webkit-margin-end: unset; */
+    /* margin-inline-end: unset; */
 }
-textarea.form-control-sm {
-  min-height: calc(1.5em + 0.5rem + calc(var(--bs-border-width) * 2));
+
+.form-control-lg::file-selector-button {
+    padding: 1rem 1.5rem;
+    margin: -1rem -1.5rem;
+    margin-inline-end: 1.5rem;
+    -webkit-margin-end: initial;
 }
+
+textarea.form-control,
+.swal2-modal textarea.swal2-input {
+    min-height: calc(1.5em + 1.35rem + calc(var(--bs-border-width) * 2));
+}
+
 textarea.form-control-lg {
-  min-height: calc(1.5em + 2rem + calc(var(--bs-border-width) * 2));
+    min-height: calc(1.5em + 2rem + calc(var(--bs-border-width) * 2));
 }
 
 .form-control-color {
-  width: 3rem;
-  height: calc(1.5em + 1.35rem + calc(var(--bs-border-width) * 2));
-  padding: 0.675rem;
+    height: calc(1.5em + 1.35rem + calc(var(--bs-border-width) * 2));
+    padding: 0.675rem;
 }
-.form-control-color:not(:disabled):not([readonly]) {
-  cursor: pointer;
-}
-.form-control-color::-moz-color-swatch {
-  border: 0 !important;
-  border-radius: var(--bs-border-radius);
-}
-.form-control-color::-webkit-color-swatch {
-  border: 0 !important;
-  border-radius: var(--bs-border-radius);
-}
-.form-control-color.form-control-sm {
-  height: calc(1.5em + 0.5rem + calc(var(--bs-border-width) * 2));
-}
+
 .form-control-color.form-control-lg {
-  height: calc(1.5em + 2rem + calc(var(--bs-border-width) * 2));
+    height: calc(1.5em + 2rem + calc(var(--bs-border-width) * 2));
 }
 
 .form-select {
-  --bs-form-select-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
-  display: block;
-  width: 100%;
-  padding: 0.675rem 3.75rem 0.675rem 1.25rem;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.5;
-  color: var(--bs-body-color);
-  -webkit-appearance: none;
-     -moz-appearance: none;
-          appearance: none;
-  background-color: var(--bs-body-bg);
-  background-image: var(--bs-form-select-bg-img), var(--bs-form-select-bg-icon, none);
-  background-repeat: no-repeat;
-  background-position: right 1.25rem center;
-  background-size: 16px 12px;
-  border: var(--bs-border-width) solid var(--bs-border-color);
-  border-radius: var(--bs-border-radius);
-  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+    padding: 0.675rem 3.75rem 0.675rem 1.25rem;
+    font-size: 0.875rem;
+    background-position: right 1.25rem center;
 }
-@media (prefers-reduced-motion: reduce) {
-  .form-select {
-    transition: none;
-  }
-}
+
 .form-select:focus {
-  border-color: #a8a4f2;
-  outline: 0;
-  box-shadow: 0 0 0 1px #5149e5;
+    border-color: #a8a4f2;
+    box-shadow: 0 0 0 1px #5149e5;
 }
-.form-select[multiple], .form-select[size]:not([size="1"]) {
-  padding-right: 1.25rem;
-  background-image: none;
-}
-.form-select:disabled {
-  background-color: var(--bs-secondary-bg);
-}
-.form-select:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 var(--bs-body-color);
+
+.form-select[multiple],
+.form-select[size]:not([size="1"]) {
+    padding-right: 1.25rem;
 }
 
 .form-select-sm {
-  padding-top: 0.25rem;
-  padding-bottom: 0.25rem;
-  padding-left: 0.5rem;
-  font-size: 0.765625rem;
-  border-radius: var(--bs-border-radius-sm);
+    font-size: 0.765625rem;
 }
 
 .form-select-lg {
-  padding-top: 1rem;
-  padding-bottom: 1rem;
-  padding-left: 1.5rem;
-  font-size: 1.09375rem;
-  border-radius: var(--bs-border-radius-lg);
-}
-
-[data-bs-theme=dark] .form-select {
-  --bs-form-select-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23dee2e6' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+    padding-left: 1.5rem;
+    font-size: 1.09375rem;
 }
 
 .form-check {
-  display: block;
-  min-height: 1.3125rem;
-  padding-left: 1.7em;
-  margin-bottom: 0.125rem;
+    min-height: 1.3125rem;
+    padding-left: 1.7em;
 }
+
 .form-check .form-check-input {
-  float: left;
-  margin-left: -1.7em;
+    margin-left: -1.7em;
 }
 
 .form-check-reverse {
-  padding-right: 1.7em;
-  padding-left: 0;
-  text-align: right;
+    padding-right: 1.7em;
 }
+
 .form-check-reverse .form-check-input {
-  float: right;
-  margin-right: -1.7em;
-  margin-left: 0;
+    margin-right: -1.7em;
 }
 
 .form-check-input {
-  --bs-form-check-bg: var(--bs-body-bg);
-  flex-shrink: 0;
-  width: 1.2em;
-  height: 1.2em;
-  margin-top: 0.15em;
-  vertical-align: top;
-  -webkit-appearance: none;
-     -moz-appearance: none;
-          appearance: none;
-  background-color: var(--bs-form-check-bg);
-  background-image: var(--bs-form-check-bg-image);
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: contain;
-  border: var(--bs-border-width) solid var(--bs-border-color);
-  -webkit-print-color-adjust: exact;
-          print-color-adjust: exact;
+    width: 1.2em;
+    height: 1.2em;
+    margin-top: 0.15em;
+    color-adjust: initial;
+    print-color-adjust: exact;
 }
-.form-check-input[type=checkbox] {
-  border-radius: 0.25em;
-}
-.form-check-input[type=radio] {
-  border-radius: 50%;
-}
-.form-check-input:active {
-  filter: brightness(90%);
-}
+
 .form-check-input:focus {
-  border-color: #a8a4f2;
-  outline: 0;
-  box-shadow: 0 0 0 0.25rem rgba(81, 73, 229, 0.25);
+    border-color: #a8a4f2;
+    box-shadow: 0 0 0 0.25rem rgba(81, 73, 229, 0.25);
 }
+
 .form-check-input:checked {
-  background-color: #5149e5;
-  border-color: #5149e5;
+    background-color: #5149e5;
+    border-color: #5149e5;
 }
-.form-check-input:checked[type=checkbox] {
-  --bs-form-check-bg-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='m6 10 3 3 6-6'/%3e%3c/svg%3e");
-}
-.form-check-input:checked[type=radio] {
-  --bs-form-check-bg-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='2' fill='%23fff'/%3e%3c/svg%3e");
-}
+
 .form-check-input[type=checkbox]:indeterminate {
-  background-color: #5149e5;
-  border-color: #5149e5;
-  --bs-form-check-bg-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10h8'/%3e%3c/svg%3e");
-}
-.form-check-input:disabled {
-  pointer-events: none;
-  filter: none;
-  opacity: 0.5;
-}
-.form-check-input[disabled] ~ .form-check-label, .form-check-input:disabled ~ .form-check-label {
-  cursor: default;
-  opacity: 0.5;
+    background-color: #5149e5;
+    border-color: #5149e5;
 }
 
-.form-switch {
-  padding-left: 2.5em;
-}
-.form-switch .form-check-input {
-  --bs-form-switch-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='rgba%280, 0, 0, 0.25%29'/%3e%3c/svg%3e");
-  width: 2em;
-  margin-left: -2.5em;
-  background-image: var(--bs-form-switch-bg);
-  background-position: left center;
-  border-radius: 2em;
-  transition: background-position 0.15s ease-in-out;
-}
-@media (prefers-reduced-motion: reduce) {
-  .form-switch .form-check-input {
-    transition: none;
-  }
-}
 .form-switch .form-check-input:focus {
-  --bs-form-switch-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23a8a4f2'/%3e%3c/svg%3e");
-}
-.form-switch .form-check-input:checked {
-  background-position: right center;
-  --bs-form-switch-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23fff'/%3e%3c/svg%3e");
-}
-.form-switch.form-check-reverse {
-  padding-right: 2.5em;
-  padding-left: 0;
-}
-.form-switch.form-check-reverse .form-check-input {
-  margin-right: -2.5em;
-  margin-left: 0;
+    --bs-form-switch-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23a8a4f2'/%3e%3c/svg%3e");
 }
 
-.form-check-inline {
-  display: inline-block;
-  margin-right: 1rem;
-}
-
-.btn-check {
-  position: absolute;
-  clip: rect(0, 0, 0, 0);
-  pointer-events: none;
-}
-.btn-check[disabled] + .btn, .btn-check:disabled + .btn {
-  pointer-events: none;
-  filter: none;
-  opacity: 0.65;
-}
-
-[data-bs-theme=dark] .form-switch .form-check-input:not(:checked):not(:focus) {
-  --bs-form-switch-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='rgba%28255, 255, 255, 0.25%29'/%3e%3c/svg%3e");
-}
-
-.form-range {
-  width: 100%;
-  height: 1.5rem;
-  padding: 0;
-  -webkit-appearance: none;
-     -moz-appearance: none;
-          appearance: none;
-  background-color: transparent;
-}
-.form-range:focus {
-  outline: 0;
-}
 .form-range:focus::-webkit-slider-thumb {
-  box-shadow: 0 0 0 1px #fff, 0 0 0 1px #5149e5;
+    box-shadow: 0 0 0 1px #fff, 0 0 0 1px #5149e5;
 }
+
 .form-range:focus::-moz-range-thumb {
-  box-shadow: 0 0 0 1px #fff, 0 0 0 1px #5149e5;
+    box-shadow: 0 0 0 1px #fff, 0 0 0 1px #5149e5;
 }
-.form-range::-moz-focus-outer {
-  border: 0;
-}
+
 .form-range::-webkit-slider-thumb {
-  width: 1rem;
-  height: 1rem;
-  margin-top: -0.25rem;
-  -webkit-appearance: none;
-          appearance: none;
-  background-color: #5149e5;
-  border: 0;
-  border-radius: 1rem;
-  -webkit-transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+    background-color: #5149e5;
 }
-@media (prefers-reduced-motion: reduce) {
-  .form-range::-webkit-slider-thumb {
-    -webkit-transition: none;
-    transition: none;
-  }
-}
+
 .form-range::-webkit-slider-thumb:active {
-  background-color: #cbc8f7;
+    background-color: #cbc8f7;
 }
-.form-range::-webkit-slider-runnable-track {
-  width: 100%;
-  height: 0.5rem;
-  color: transparent;
-  cursor: pointer;
-  background-color: var(--bs-secondary-bg);
-  border-color: transparent;
-  border-radius: 1rem;
-}
+
 .form-range::-moz-range-thumb {
-  width: 1rem;
-  height: 1rem;
-  -moz-appearance: none;
-       appearance: none;
-  background-color: #5149e5;
-  border: 0;
-  border-radius: 1rem;
-  -moz-transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+    background-color: #5149e5;
 }
-@media (prefers-reduced-motion: reduce) {
-  .form-range::-moz-range-thumb {
-    -moz-transition: none;
-    transition: none;
-  }
-}
+
 .form-range::-moz-range-thumb:active {
-  background-color: #cbc8f7;
-}
-.form-range::-moz-range-track {
-  width: 100%;
-  height: 0.5rem;
-  color: transparent;
-  cursor: pointer;
-  background-color: var(--bs-secondary-bg);
-  border-color: transparent;
-  border-radius: 1rem;
-}
-.form-range:disabled {
-  pointer-events: none;
-}
-.form-range:disabled::-webkit-slider-thumb {
-  background-color: var(--bs-secondary-color);
-}
-.form-range:disabled::-moz-range-thumb {
-  background-color: var(--bs-secondary-color);
+    background-color: #cbc8f7;
 }
 
-.form-floating {
-  position: relative;
-}
-.form-floating > .form-control, .swal2-modal .form-floating > .swal2-input,
-.form-floating > .form-control-plaintext,
-.form-floating > .form-select {
-  height: calc(3.5rem + calc(var(--bs-border-width) * 2));
-  min-height: calc(3.5rem + calc(var(--bs-border-width) * 2));
-  line-height: 1.25;
-}
-.form-floating > label {
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 2;
-  height: 100%;
-  padding: 1rem 1.25rem;
-  overflow: hidden;
-  text-align: start;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  pointer-events: none;
-  border: var(--bs-border-width) solid transparent;
-  transform-origin: 0 0;
-  transition: opacity 0.1s ease-in-out, transform 0.1s ease-in-out;
-}
-@media (prefers-reduced-motion: reduce) {
-  .form-floating > label {
-    transition: none;
-  }
-}
-.form-floating > .form-control, .swal2-modal .form-floating > .swal2-input,
-.form-floating > .form-control-plaintext {
-  padding: 1rem 1.25rem;
-}
-.form-floating > .form-control::-moz-placeholder, .swal2-modal .form-floating > .swal2-input::-moz-placeholder, .form-floating > .form-control-plaintext::-moz-placeholder {
-  color: transparent;
-}
-.form-floating > .form-control::placeholder, .swal2-modal .form-floating > .swal2-input::placeholder,
-.form-floating > .form-control-plaintext::placeholder {
-  color: transparent;
-}
-.form-floating > .form-control:not(:-moz-placeholder-shown), .swal2-modal .form-floating > .swal2-input:not(:-moz-placeholder-shown), .form-floating > .form-control-plaintext:not(:-moz-placeholder-shown) {
-  padding-top: 1.625rem;
-  padding-bottom: 0.625rem;
-}
-.form-floating > .form-control:focus, .swal2-modal .form-floating > .swal2-input:focus, .form-floating > .form-control:not(:placeholder-shown), .swal2-modal .form-floating > .swal2-input:not(:placeholder-shown),
-.form-floating > .form-control-plaintext:focus,
-.form-floating > .form-control-plaintext:not(:placeholder-shown) {
-  padding-top: 1.625rem;
-  padding-bottom: 0.625rem;
-}
-.form-floating > .form-control:-webkit-autofill, .swal2-modal .form-floating > .swal2-input:-webkit-autofill,
-.form-floating > .form-control-plaintext:-webkit-autofill {
-  padding-top: 1.625rem;
-  padding-bottom: 0.625rem;
-}
-.form-floating > .form-select {
-  padding-top: 1.625rem;
-  padding-bottom: 0.625rem;
-}
-.form-floating > .form-control:not(:-moz-placeholder-shown) ~ label, .swal2-modal .form-floating > .swal2-input:not(:-moz-placeholder-shown) ~ label {
-  color: rgba(var(--bs-body-color-rgb), 0.65);
-  transform: scale(0.85) translateY(-0.5rem) translateX(0.15rem);
-}
-.form-floating > .form-control:focus ~ label, .swal2-modal .form-floating > .swal2-input:focus ~ label,
-.form-floating > .form-control:not(:placeholder-shown) ~ label,
-.swal2-modal .form-floating > .swal2-input:not(:placeholder-shown) ~ label,
-.form-floating > .form-control-plaintext ~ label,
-.form-floating > .form-select ~ label {
-  color: rgba(var(--bs-body-color-rgb), 0.65);
-  transform: scale(0.85) translateY(-0.5rem) translateX(0.15rem);
-}
-.form-floating > .form-control:not(:-moz-placeholder-shown) ~ label::after, .swal2-modal .form-floating > .swal2-input:not(:-moz-placeholder-shown) ~ label::after {
-  position: absolute;
-  inset: 1rem 0.625rem;
-  z-index: -1;
-  height: 1.5em;
-  content: "";
-  background-color: var(--bs-body-bg);
-  border-radius: var(--bs-border-radius);
-}
-.form-floating > .form-control:focus ~ label::after, .swal2-modal .form-floating > .swal2-input:focus ~ label::after,
-.form-floating > .form-control:not(:placeholder-shown) ~ label::after,
-.swal2-modal .form-floating > .swal2-input:not(:placeholder-shown) ~ label::after,
-.form-floating > .form-control-plaintext ~ label::after,
-.form-floating > .form-select ~ label::after {
-  position: absolute;
-  inset: 1rem 0.625rem;
-  z-index: -1;
-  height: 1.5em;
-  content: "";
-  background-color: var(--bs-body-bg);
-  border-radius: var(--bs-border-radius);
-}
-.form-floating > .form-control:-webkit-autofill ~ label, .swal2-modal .form-floating > .swal2-input:-webkit-autofill ~ label {
-  color: rgba(var(--bs-body-color-rgb), 0.65);
-  transform: scale(0.85) translateY(-0.5rem) translateX(0.15rem);
-}
-.form-floating > .form-control-plaintext ~ label {
-  border-width: var(--bs-border-width) 0;
-}
-.form-floating > :disabled ~ label,
-.form-floating > .form-control:disabled ~ label {
-  color: #6c757d;
-}
-.form-floating > :disabled ~ label::after,
-.form-floating > .form-control:disabled ~ label::after {
-  background-color: var(--bs-secondary-bg);
+.form-floating>.form-control,
+.swal2-modal .form-floating>.swal2-input,
+.form-floating>.form-control-plaintext,
+.form-floating>.form-select {
+    height: calc(3.5rem + calc(var(--bs-border-width) * 2));
+    min-height: calc(3.5rem + calc(var(--bs-border-width) * 2));
+    line-height: 1.25;
 }
 
-.input-group {
-  position: relative;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: stretch;
-  width: 100%;
+.form-floating>label {
+    padding: 1rem 1.25rem;
 }
-.input-group > .form-control, .swal2-modal .input-group > .swal2-input,
-.input-group > .form-select,
-.input-group > .form-floating {
-  position: relative;
-  flex: 1 1 auto;
-  width: 1%;
-  min-width: 0;
+
+.form-floating>.form-control,
+.swal2-modal .form-floating>.swal2-input,
+.form-floating>.form-control-plaintext {
+    padding: 1rem 1.25rem;
 }
-.input-group > .form-control:focus, .swal2-modal .input-group > .swal2-input:focus,
-.input-group > .form-select:focus,
-.input-group > .form-floating:focus-within {
-  z-index: 5;
+
+.form-floating>.form-control::-moz-placeholder,
+.swal2-modal .form-floating>.swal2-input::-moz-placeholder,
+.form-floating>.form-control-plaintext::-moz-placeholder {
+    color: transparent;
 }
-.input-group .btn {
-  position: relative;
-  z-index: 2;
+
+.form-floating>.form-control::placeholder,
+.swal2-modal .form-floating>.swal2-input::placeholder,
+.form-floating>.form-control-plaintext::placeholder {
+    color: transparent;
 }
-.input-group .btn:focus {
-  z-index: 5;
+
+.form-floating>.form-control:not(:-moz-placeholder-shown),
+.swal2-modal .form-floating>.swal2-input:not(:-moz-placeholder-shown),
+.form-floating>.form-control-plaintext:not(:-moz-placeholder-shown) {
+    padding-top: 1.625rem;
+    padding-bottom: 0.625rem;
+}
+
+.form-floating>.form-control:focus,
+.swal2-modal .form-floating>.swal2-input:focus,
+.form-floating>.form-control:not(:placeholder-shown),
+.swal2-modal .form-floating>.swal2-input:not(:placeholder-shown),
+.form-floating>.form-control-plaintext:focus,
+.form-floating>.form-control-plaintext:not(:placeholder-shown) {
+    padding-top: 1.625rem;
+    padding-bottom: 0.625rem;
+}
+
+.form-floating>.form-control:-webkit-autofill,
+.swal2-modal .form-floating>.swal2-input:-webkit-autofill,
+.form-floating>.form-control-plaintext:-webkit-autofill {
+    padding-top: 1.625rem;
+    padding-bottom: 0.625rem;
+}
+
+.form-floating>.form-select {
+    padding-top: 1.625rem;
+    padding-bottom: 0.625rem;
+}
+
+.form-floating>.form-control:not(:-moz-placeholder-shown)~label,
+.swal2-modal .form-floating>.swal2-input:not(:-moz-placeholder-shown)~label {
+    color: rgba(var(--bs-body-color-rgb), 0.65);
+    transform: scale(0.85) translateY(-0.5rem) translateX(0.15rem);
+}
+
+.form-floating>.form-control:focus~label,
+.swal2-modal .form-floating>.swal2-input:focus~label,
+.form-floating>.form-control:not(:placeholder-shown)~label,
+.swal2-modal .form-floating>.swal2-input:not(:placeholder-shown)~label,
+.form-floating>.form-control-plaintext~label,
+.form-floating>.form-select~label {
+    color: rgba(var(--bs-body-color-rgb), 0.65);
+    transform: scale(0.85) translateY(-0.5rem) translateX(0.15rem);
+}
+
+.form-floating>.form-control:not(:-moz-placeholder-shown)~label::after,
+.swal2-modal .form-floating>.swal2-input:not(:-moz-placeholder-shown)~label::after {
+    position: absolute;
+    inset: 1rem 0.625rem;
+    z-index: -1;
+    height: 1.5em;
+    content: "";
+    background-color: var(--bs-body-bg);
+    border-radius: var(--bs-border-radius);
+}
+
+.form-floating>.form-control:focus~label::after,
+.swal2-modal .form-floating>.swal2-input:focus~label::after,
+.form-floating>.form-control:not(:placeholder-shown)~label::after,
+.swal2-modal .form-floating>.swal2-input:not(:placeholder-shown)~label::after,
+.form-floating>.form-control-plaintext~label::after,
+.form-floating>.form-select~label::after {
+    position: absolute;
+    inset: 1rem 0.625rem;
+    z-index: -1;
+    height: 1.5em;
+    content: "";
+    background-color: var(--bs-body-bg);
+    border-radius: var(--bs-border-radius);
+}
+
+.form-floating>.form-control:-webkit-autofill~label,
+.swal2-modal .form-floating>.swal2-input:-webkit-autofill~label {
+    color: rgba(var(--bs-body-color-rgb), 0.65);
+    transform: scale(0.85) translateY(-0.5rem) translateX(0.15rem);
+}
+
+.form-floating>.form-control-plaintext~label {
+    border-width: var(--bs-border-width) 0;
+}
+
+.form-floating> :disabled~label,
+.form-floating>.form-control:disabled~label {
+    color: #6c757d;
+}
+
+.form-floating> :disabled~label::after,
+.form-floating>.form-control:disabled~label::after {
+    background-color: var(--bs-secondary-bg);
+}
+
+.input-group>.form-control,
+.swal2-modal .input-group>.swal2-input,
+.input-group>.form-select,
+.input-group>.form-floating {
+    position: relative;
+    flex: 1 1 auto;
+    width: 1%;
+    min-width: 0;
+}
+
+.input-group>.form-control:focus,
+.swal2-modal .input-group>.swal2-input:focus,
+.input-group>.form-select:focus,
+.input-group>.form-floating:focus-within {
+    z-index: 5;
 }
 
 .input-group-text {
-  display: flex;
-  align-items: center;
-  padding: 0.675rem 1.25rem;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.5;
-  color: var(--bs-body-color);
-  text-align: center;
-  white-space: nowrap;
-  background-color: var(--bs-tertiary-bg);
-  border: var(--bs-border-width) solid var(--bs-border-color);
-  border-radius: var(--bs-border-radius);
+    padding: 0.675rem 1.25rem;
+    font-size: 0.875rem;
 }
 
-.input-group-lg > .form-control, .swal2-modal .input-group-lg > .swal2-input,
-.input-group-lg > .form-select,
-.input-group-lg > .input-group-text,
-.input-group-lg > .btn {
-  padding: 1rem 1.5rem;
-  font-size: 1.09375rem;
-  border-radius: var(--bs-border-radius-lg);
+
+.input-group-lg>.form-control,
+.swal2-modal .input-group-lg>.swal2-input,
+.input-group-lg>.form-select,
+.input-group-lg>.input-group-text,
+.input-group-lg>.btn {
+    padding: 1rem 1.5rem;
+    font-size: 1.09375rem;
+    border-radius: var(--bs-border-radius-lg);
 }
 
-.input-group-sm > .form-control, .swal2-modal .input-group-sm > .swal2-input,
-.input-group-sm > .form-select,
-.input-group-sm > .input-group-text,
-.input-group-sm > .btn {
-  padding: 0.25rem 0.5rem;
-  font-size: 0.765625rem;
-  border-radius: var(--bs-border-radius-sm);
+.input-group-sm>.form-control,
+.swal2-modal .input-group-sm>.swal2-input,
+.input-group-sm>.form-select,
+.input-group-sm>.input-group-text,
+.input-group-sm>.btn {
+    padding: 0.25rem 0.5rem;
+    font-size: 0.765625rem;
+    border-radius: var(--bs-border-radius-sm);
 }
 
-.input-group-lg > .form-select,
-.input-group-sm > .form-select {
-  padding-right: 5rem;
+.input-group-lg>.form-select,
+.input-group-sm>.form-select {
+    padding-right: 5rem;
 }
 
-.input-group:not(.has-validation) > :not(:last-child):not(.dropdown-toggle):not(.dropdown-menu):not(.form-floating),
-.input-group:not(.has-validation) > .dropdown-toggle:nth-last-child(n+3),
-.input-group:not(.has-validation) > .form-floating:not(:last-child) > .form-control,
-.swal2-modal .input-group:not(.has-validation) > .form-floating:not(:last-child) > .swal2-input,
-.input-group:not(.has-validation) > .form-floating:not(:last-child) > .form-select {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-.input-group.has-validation > :nth-last-child(n+3):not(.dropdown-toggle):not(.dropdown-menu):not(.form-floating),
-.input-group.has-validation > .dropdown-toggle:nth-last-child(n+4),
-.input-group.has-validation > .form-floating:nth-last-child(n+3) > .form-control,
-.swal2-modal .input-group.has-validation > .form-floating:nth-last-child(n+3) > .swal2-input,
-.input-group.has-validation > .form-floating:nth-last-child(n+3) > .form-select {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-.input-group > :not(:first-child):not(.dropdown-menu):not(.valid-tooltip):not(.valid-feedback):not(.invalid-tooltip):not(.invalid-feedback) {
-  margin-left: calc(var(--bs-border-width) * -1);
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-}
-.input-group > .form-floating:not(:first-child) > .form-control, .swal2-modal .input-group > .form-floating:not(:first-child) > .swal2-input,
-.input-group > .form-floating:not(:first-child) > .form-select {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
+.input-group:not(.has-validation)> :not(:last-child):not(.dropdown-toggle):not(.dropdown-menu):not(.form-floating),
+.input-group:not(.has-validation)>.dropdown-toggle:nth-last-child(n+3),
+.input-group:not(.has-validation)>.form-floating:not(:last-child)>.form-control,
+.swal2-modal .input-group:not(.has-validation)>.form-floating:not(:last-child)>.swal2-input,
+.input-group:not(.has-validation)>.form-floating:not(:last-child)>.form-select {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
 }
 
-.valid-feedback {
-  display: none;
-  width: 100%;
-  margin-top: 0.25rem;
-  font-size: 0.875em;
-  color: var(--bs-form-valid-color);
+.input-group.has-validation> :nth-last-child(n+3):not(.dropdown-toggle):not(.dropdown-menu):not(.form-floating),
+.input-group.has-validation>.dropdown-toggle:nth-last-child(n+4),
+.input-group.has-validation>.form-floating:nth-last-child(n+3)>.form-control,
+.swal2-modal .input-group.has-validation>.form-floating:nth-last-child(n+3)>.swal2-input,
+.input-group.has-validation>.form-floating:nth-last-child(n+3)>.form-select {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
 }
+
+.input-group> :not(:first-child):not(.dropdown-menu):not(.valid-tooltip):not(.valid-feedback):not(.invalid-tooltip):not(.invalid-feedback) {
+    margin-left: calc(var(--bs-border-width) * -1);
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+}
+
+.input-group>.form-floating:not(:first-child)>.form-control,
+.swal2-modal .input-group>.form-floating:not(:first-child)>.swal2-input,
+.input-group>.form-floating:not(:first-child)>.form-select {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+}
+
 
 .valid-tooltip {
-  position: absolute;
-  top: 100%;
-  z-index: 5;
-  display: none;
-  max-width: 100%;
-  padding: 0.25rem 0.5rem;
-  margin-top: 0.1rem;
-  font-size: 0.765625rem;
-  color: #fff;
-  background-color: var(--bs-success);
-  border-radius: var(--bs-border-radius);
+    font-size: 0.765625rem;
 }
 
-.was-validated :valid ~ .valid-feedback,
-.was-validated :valid ~ .valid-tooltip,
-.is-valid ~ .valid-feedback,
-.is-valid ~ .valid-tooltip {
-  display: block;
+.was-validated .form-control:valid,
+.was-validated .swal2-modal .swal2-input:valid,
+.swal2-modal .was-validated .swal2-input:valid,
+.form-control.is-valid,
+.swal2-modal .is-valid.swal2-input {
+    border-color: var(--bs-form-valid-border-color);
+    padding-right: calc(1.5em + 1.35rem);
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%2305b171' d='M2.3 6.73.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right calc(0.375em + 0.3375rem) center;
+    background-size: calc(0.75em + 0.675rem) calc(0.75em + 0.675rem);
 }
 
-.was-validated .form-control:valid, .was-validated .swal2-modal .swal2-input:valid, .swal2-modal .was-validated .swal2-input:valid, .form-control.is-valid, .swal2-modal .is-valid.swal2-input {
-  border-color: var(--bs-form-valid-border-color);
-  padding-right: calc(1.5em + 1.35rem);
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%2305b171' d='M2.3 6.73.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e");
-  background-repeat: no-repeat;
-  background-position: right calc(0.375em + 0.3375rem) center;
-  background-size: calc(0.75em + 0.675rem) calc(0.75em + 0.675rem);
-}
-.was-validated .form-control:valid:focus, .was-validated .swal2-modal .swal2-input:valid:focus, .swal2-modal .was-validated .swal2-input:valid:focus, .form-control.is-valid:focus, .swal2-modal .is-valid.swal2-input:focus {
-  border-color: var(--bs-form-valid-border-color);
-  box-shadow: 0 0 0 0.25rem rgba(var(--bs-success-rgb), 0.25);
+.was-validated .form-control:valid:focus,
+.was-validated .swal2-modal .swal2-input:valid:focus,
+.swal2-modal .was-validated .swal2-input:valid:focus,
+.form-control.is-valid:focus,
+.swal2-modal .is-valid.swal2-input:focus {
+    border-color: var(--bs-form-valid-border-color);
+    box-shadow: 0 0 0 0.25rem rgba(var(--bs-success-rgb), 0.25);
 }
 
-.was-validated textarea.form-control:valid, .was-validated .swal2-modal textarea.swal2-input:valid, .swal2-modal .was-validated textarea.swal2-input:valid, textarea.form-control.is-valid, .swal2-modal textarea.is-valid.swal2-input {
-  padding-right: calc(1.5em + 1.35rem);
-  background-position: top calc(0.375em + 0.3375rem) right calc(0.375em + 0.3375rem);
+.was-validated textarea.form-control:valid,
+.was-validated .swal2-modal textarea.swal2-input:valid,
+.swal2-modal .was-validated textarea.swal2-input:valid,
+textarea.form-control.is-valid,
+.swal2-modal textarea.is-valid.swal2-input {
+    padding-right: calc(1.5em + 1.35rem);
+    background-position: top calc(0.375em + 0.3375rem) right calc(0.375em + 0.3375rem);
 }
 
-.was-validated .form-select:valid, .form-select.is-valid {
-  border-color: var(--bs-form-valid-border-color);
-}
-.was-validated .form-select:valid:not([multiple]):not([size]), .was-validated .form-select:valid:not([multiple])[size="1"], .form-select.is-valid:not([multiple]):not([size]), .form-select.is-valid:not([multiple])[size="1"] {
-  --bs-form-select-bg-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%2305b171' d='M2.3 6.73.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e");
-  padding-right: 6.875rem;
-  background-position: right 1.25rem center, center right 3.75rem;
-  background-size: 16px 12px, calc(0.75em + 0.675rem) calc(0.75em + 0.675rem);
-}
-.was-validated .form-select:valid:focus, .form-select.is-valid:focus {
-  border-color: var(--bs-form-valid-border-color);
-  box-shadow: 0 0 0 0.25rem rgba(var(--bs-success-rgb), 0.25);
+.was-validated .form-select:valid:not([multiple]):not([size]),
+.was-validated .form-select:valid:not([multiple])[size="1"],
+.form-select.is-valid:not([multiple]):not([size]),
+.form-select.is-valid:not([multiple])[size="1"] {
+    --bs-form-select-bg-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%2305b171' d='M2.3 6.73.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e");
+    padding-right: 6.875rem;
+    background-position: right 1.25rem center, center right 3.75rem;
+    background-size: 16px 12px, calc(0.75em + 0.675rem) calc(0.75em + 0.675rem);
 }
 
-.was-validated .form-control-color:valid, .form-control-color.is-valid {
-  width: calc(3rem + calc(1.5em + 1.35rem));
+.was-validated .form-control-color:valid,
+.form-control-color.is-valid {
+    width: calc(3rem + calc(1.5em + 1.35rem));
 }
 
-.was-validated .form-check-input:valid, .form-check-input.is-valid {
-  border-color: var(--bs-form-valid-border-color);
-}
-.was-validated .form-check-input:valid:checked, .form-check-input.is-valid:checked {
-  background-color: var(--bs-form-valid-color);
-}
-.was-validated .form-check-input:valid:focus, .form-check-input.is-valid:focus {
-  box-shadow: 0 0 0 0.25rem rgba(var(--bs-success-rgb), 0.25);
-}
-.was-validated .form-check-input:valid ~ .form-check-label, .form-check-input.is-valid ~ .form-check-label {
-  color: var(--bs-form-valid-color);
-}
-
-.form-check-inline .form-check-input ~ .valid-feedback {
-  margin-left: 0.5em;
+.was-validated .input-group>.form-control:not(:focus):valid,
+.was-validated .swal2-modal .input-group>.swal2-input:not(:focus):valid,
+.swal2-modal .was-validated .input-group>.swal2-input:not(:focus):valid,
+.input-group>.form-control:not(:focus).is-valid,
+.swal2-modal .input-group>.swal2-input:not(:focus).is-valid,
+.was-validated .input-group>.form-select:not(:focus):valid,
+.input-group>.form-select:not(:focus).is-valid,
+.was-validated .input-group>.form-floating:not(:focus-within):valid,
+.input-group>.form-floating:not(:focus-within).is-valid {
+    z-index: 3;
 }
 
-.was-validated .input-group > .form-control:not(:focus):valid, .was-validated .swal2-modal .input-group > .swal2-input:not(:focus):valid, .swal2-modal .was-validated .input-group > .swal2-input:not(:focus):valid, .input-group > .form-control:not(:focus).is-valid, .swal2-modal .input-group > .swal2-input:not(:focus).is-valid,
-.was-validated .input-group > .form-select:not(:focus):valid,
-.input-group > .form-select:not(:focus).is-valid,
-.was-validated .input-group > .form-floating:not(:focus-within):valid,
-.input-group > .form-floating:not(:focus-within).is-valid {
-  z-index: 3;
-}
-
-.invalid-feedback {
-  display: none;
-  width: 100%;
-  margin-top: 0.25rem;
-  font-size: 0.875em;
-  color: var(--bs-form-invalid-color);
-}
 
 .invalid-tooltip {
-  position: absolute;
-  top: 100%;
-  z-index: 5;
-  display: none;
-  max-width: 100%;
-  padding: 0.25rem 0.5rem;
-  margin-top: 0.1rem;
-  font-size: 0.765625rem;
-  color: #fff;
-  background-color: var(--bs-danger);
-  border-radius: var(--bs-border-radius);
+    font-size: 0.765625rem;
 }
 
-.was-validated :invalid ~ .invalid-feedback,
-.was-validated :invalid ~ .invalid-tooltip,
-.is-invalid ~ .invalid-feedback,
-.is-invalid ~ .invalid-tooltip {
-  display: block;
+.was-validated .form-control:invalid,
+.was-validated .swal2-modal .swal2-input:invalid,
+.swal2-modal .was-validated .swal2-input:invalid,
+.form-control.is-invalid,
+.swal2-modal .is-invalid.swal2-input {
+    border-color: var(--bs-form-invalid-border-color);
+    padding-right: calc(1.5em + 1.35rem);
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23ea4444'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23ea4444' stroke='none'/%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right calc(0.375em + 0.3375rem) center;
+    background-size: calc(0.75em + 0.675rem) calc(0.75em + 0.675rem);
 }
 
-.was-validated .form-control:invalid, .was-validated .swal2-modal .swal2-input:invalid, .swal2-modal .was-validated .swal2-input:invalid, .form-control.is-invalid, .swal2-modal .is-invalid.swal2-input {
-  border-color: var(--bs-form-invalid-border-color);
-  padding-right: calc(1.5em + 1.35rem);
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23ea4444'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23ea4444' stroke='none'/%3e%3c/svg%3e");
-  background-repeat: no-repeat;
-  background-position: right calc(0.375em + 0.3375rem) center;
-  background-size: calc(0.75em + 0.675rem) calc(0.75em + 0.675rem);
-}
-.was-validated .form-control:invalid:focus, .was-validated .swal2-modal .swal2-input:invalid:focus, .swal2-modal .was-validated .swal2-input:invalid:focus, .form-control.is-invalid:focus, .swal2-modal .is-invalid.swal2-input:focus {
-  border-color: var(--bs-form-invalid-border-color);
-  box-shadow: 0 0 0 0.25rem rgba(var(--bs-danger-rgb), 0.25);
+.was-validated .form-control:invalid:focus,
+.was-validated .swal2-modal .swal2-input:invalid:focus,
+.swal2-modal .was-validated .swal2-input:invalid:focus,
+.form-control.is-invalid:focus,
+.swal2-modal .is-invalid.swal2-input:focus {
+    border-color: var(--bs-form-invalid-border-color);
+    box-shadow: 0 0 0 0.25rem rgba(var(--bs-danger-rgb), 0.25);
 }
 
-.was-validated textarea.form-control:invalid, .was-validated .swal2-modal textarea.swal2-input:invalid, .swal2-modal .was-validated textarea.swal2-input:invalid, textarea.form-control.is-invalid, .swal2-modal textarea.is-invalid.swal2-input {
-  padding-right: calc(1.5em + 1.35rem);
-  background-position: top calc(0.375em + 0.3375rem) right calc(0.375em + 0.3375rem);
+.was-validated textarea.form-control:invalid,
+.was-validated .swal2-modal textarea.swal2-input:invalid,
+.swal2-modal .was-validated textarea.swal2-input:invalid,
+textarea.form-control.is-invalid,
+.swal2-modal textarea.is-invalid.swal2-input {
+    padding-right: calc(1.5em + 1.35rem);
+    background-position: top calc(0.375em + 0.3375rem) right calc(0.375em + 0.3375rem);
 }
 
-.was-validated .form-select:invalid, .form-select.is-invalid {
-  border-color: var(--bs-form-invalid-border-color);
-}
-.was-validated .form-select:invalid:not([multiple]):not([size]), .was-validated .form-select:invalid:not([multiple])[size="1"], .form-select.is-invalid:not([multiple]):not([size]), .form-select.is-invalid:not([multiple])[size="1"] {
-  --bs-form-select-bg-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23ea4444'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23ea4444' stroke='none'/%3e%3c/svg%3e");
-  padding-right: 6.875rem;
-  background-position: right 1.25rem center, center right 3.75rem;
-  background-size: 16px 12px, calc(0.75em + 0.675rem) calc(0.75em + 0.675rem);
-}
-.was-validated .form-select:invalid:focus, .form-select.is-invalid:focus {
-  border-color: var(--bs-form-invalid-border-color);
-  box-shadow: 0 0 0 0.25rem rgba(var(--bs-danger-rgb), 0.25);
+.was-validated .form-select:invalid:not([multiple]):not([size]),
+.was-validated .form-select:invalid:not([multiple])[size="1"],
+.form-select.is-invalid:not([multiple]):not([size]),
+.form-select.is-invalid:not([multiple])[size="1"] {
+    --bs-form-select-bg-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23ea4444'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23ea4444' stroke='none'/%3e%3c/svg%3e");
+    padding-right: 6.875rem;
+    background-position: right 1.25rem center, center right 3.75rem;
+    background-size: 16px 12px, calc(0.75em + 0.675rem) calc(0.75em + 0.675rem);
 }
 
-.was-validated .form-control-color:invalid, .form-control-color.is-invalid {
-  width: calc(3rem + calc(1.5em + 1.35rem));
+.was-validated .form-control-color:invalid,
+.form-control-color.is-invalid {
+    width: calc(3rem + calc(1.5em + 1.35rem));
 }
 
-.was-validated .form-check-input:invalid, .form-check-input.is-invalid {
-  border-color: var(--bs-form-invalid-border-color);
-}
-.was-validated .form-check-input:invalid:checked, .form-check-input.is-invalid:checked {
-  background-color: var(--bs-form-invalid-color);
-}
-.was-validated .form-check-input:invalid:focus, .form-check-input.is-invalid:focus {
-  box-shadow: 0 0 0 0.25rem rgba(var(--bs-danger-rgb), 0.25);
-}
-.was-validated .form-check-input:invalid ~ .form-check-label, .form-check-input.is-invalid ~ .form-check-label {
-  color: var(--bs-form-invalid-color);
-}
 
-.form-check-inline .form-check-input ~ .invalid-feedback {
-  margin-left: 0.5em;
-}
-
-.was-validated .input-group > .form-control:not(:focus):invalid, .was-validated .swal2-modal .input-group > .swal2-input:not(:focus):invalid, .swal2-modal .was-validated .input-group > .swal2-input:not(:focus):invalid, .input-group > .form-control:not(:focus).is-invalid, .swal2-modal .input-group > .swal2-input:not(:focus).is-invalid,
-.was-validated .input-group > .form-select:not(:focus):invalid,
-.input-group > .form-select:not(:focus).is-invalid,
-.was-validated .input-group > .form-floating:not(:focus-within):invalid,
-.input-group > .form-floating:not(:focus-within).is-invalid {
-  z-index: 4;
+.was-validated .input-group>.form-control:not(:focus):invalid,
+.was-validated .swal2-modal .input-group>.swal2-input:not(:focus):invalid,
+.swal2-modal .was-validated .input-group>.swal2-input:not(:focus):invalid,
+.input-group>.form-control:not(:focus).is-invalid,
+.swal2-modal .input-group>.swal2-input:not(:focus).is-invalid,
+.was-validated .input-group>.form-select:not(:focus):invalid,
+.input-group>.form-select:not(:focus).is-invalid,
+.was-validated .input-group>.form-floating:not(:focus-within):invalid,
+.input-group>.form-floating:not(:focus-within).is-invalid {
+    z-index: 4;
 }
 
 .btn {
-  --bs-btn-padding-x: 1.25rem;
-  --bs-btn-padding-y: 0.675rem;
-  --bs-btn-font-family: ;
-  --bs-btn-font-size: 0.875rem;
-  --bs-btn-font-weight: 400;
-  --bs-btn-line-height: 1.5;
-  --bs-btn-color: var(--bs-body-color);
-  --bs-btn-bg: transparent;
-  --bs-btn-border-width: var(--bs-border-width);
-  --bs-btn-border-color: transparent;
-  --bs-btn-border-radius: var(--bs-border-radius);
-  --bs-btn-hover-border-color: transparent;
-  --bs-btn-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15), 0 1px 1px rgba(0, 0, 0, 0.075);
-  --bs-btn-disabled-opacity: 0.65;
-  --bs-btn-focus-box-shadow: 0 0 0 0.25rem rgba(var(--bs-btn-focus-shadow-rgb), .5);
-  display: inline-block;
-  padding: var(--bs-btn-padding-y) var(--bs-btn-padding-x);
-  font-family: var(--bs-btn-font-family);
-  font-size: var(--bs-btn-font-size);
-  font-weight: var(--bs-btn-font-weight);
-  line-height: var(--bs-btn-line-height);
-  color: var(--bs-btn-color);
-  text-align: center;
-  text-decoration: none;
-  vertical-align: middle;
-  cursor: pointer;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-          user-select: none;
-  border: var(--bs-btn-border-width) solid var(--bs-btn-border-color);
-  border-radius: var(--bs-btn-border-radius);
-  background-color: var(--bs-btn-bg);
-  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-}
-@media (prefers-reduced-motion: reduce) {
-  .btn {
-    transition: none;
-  }
-}
-.btn:hover {
-  color: var(--bs-btn-hover-color);
-  background-color: var(--bs-btn-hover-bg);
-  border-color: var(--bs-btn-hover-border-color);
-}
-.btn-check + .btn:hover {
-  color: var(--bs-btn-color);
-  background-color: var(--bs-btn-bg);
-  border-color: var(--bs-btn-border-color);
-}
-.btn:focus-visible {
-  color: var(--bs-btn-hover-color);
-  background-color: var(--bs-btn-hover-bg);
-  border-color: var(--bs-btn-hover-border-color);
-  outline: 0;
-  box-shadow: var(--bs-btn-focus-box-shadow);
-}
-.btn-check:focus-visible + .btn {
-  border-color: var(--bs-btn-hover-border-color);
-  outline: 0;
-  box-shadow: var(--bs-btn-focus-box-shadow);
-}
-.btn-check:checked + .btn, :not(.btn-check) + .btn:active, .btn:first-child:active, .btn.active, .btn.show {
-  color: var(--bs-btn-active-color);
-  background-color: var(--bs-btn-active-bg);
-  border-color: var(--bs-btn-active-border-color);
-}
-.btn-check:checked + .btn:focus-visible, :not(.btn-check) + .btn:active:focus-visible, .btn:first-child:active:focus-visible, .btn.active:focus-visible, .btn.show:focus-visible {
-  box-shadow: var(--bs-btn-focus-box-shadow);
-}
-.btn:disabled, .btn.disabled, fieldset:disabled .btn {
-  color: var(--bs-btn-disabled-color);
-  pointer-events: none;
-  background-color: var(--bs-btn-disabled-bg);
-  border-color: var(--bs-btn-disabled-border-color);
-  opacity: var(--bs-btn-disabled-opacity);
+    --bs-btn-padding-x: 1.25rem;
+    --bs-btn-padding-y: 0.675rem;
+    --bs-btn-font-size: 0.875rem;
 }
 
 .btn-primary {
-  --bs-btn-color: #fff;
-  --bs-btn-bg: #5149e5;
-  --bs-btn-border-color: #5149e5;
-  --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #453ec3;
-  --bs-btn-hover-border-color: #413ab7;
-  --bs-btn-focus-shadow-rgb: 107, 100, 233;
-  --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #413ab7;
-  --bs-btn-active-border-color: #3d37ac;
-  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #fff;
-  --bs-btn-disabled-bg: #5149e5;
-  --bs-btn-disabled-border-color: #5149e5;
+    --bs-btn-bg: #5149e5;
+    --bs-btn-border-color: #5149e5;
+    --bs-btn-hover-bg: #453ec3;
+    --bs-btn-hover-border-color: #413ab7;
+    --bs-btn-focus-shadow-rgb: 107, 100, 233;
+    --bs-btn-active-bg: #413ab7;
+    --bs-btn-active-border-color: #3d37ac;
+    --bs-btn-disabled-bg: #5149e5;
+    --bs-btn-disabled-border-color: #5149e5;
 }
+
 
 .btn-secondary {
-  --bs-btn-color: #fff;
-  --bs-btn-bg: #9932e7;
-  --bs-btn-border-color: #9932e7;
-  --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #822bc4;
-  --bs-btn-hover-border-color: #7a28b9;
-  --bs-btn-focus-shadow-rgb: 168, 81, 235;
-  --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #7a28b9;
-  --bs-btn-active-border-color: #7326ad;
-  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #fff;
-  --bs-btn-disabled-bg: #9932e7;
-  --bs-btn-disabled-border-color: #9932e7;
+    --bs-btn-bg: #9932e7;
+    --bs-btn-border-color: #9932e7;
+    --bs-btn-hover-bg: #822bc4;
+    --bs-btn-hover-border-color: #7a28b9;
+    --bs-btn-focus-shadow-rgb: 168, 81, 235;
+    --bs-btn-active-bg: #7a28b9;
+    --bs-btn-active-border-color: #7326ad;
+    --bs-btn-disabled-bg: #9932e7;
+    --bs-btn-disabled-border-color: #9932e7;
 }
+
 
 .btn-success {
-  --bs-btn-color: #fff;
-  --bs-btn-bg: #05b171;
-  --bs-btn-border-color: #05b171;
-  --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #049660;
-  --bs-btn-hover-border-color: #048e5a;
-  --bs-btn-focus-shadow-rgb: 43, 189, 134;
-  --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #048e5a;
-  --bs-btn-active-border-color: #048555;
-  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #fff;
-  --bs-btn-disabled-bg: #05b171;
-  --bs-btn-disabled-border-color: #05b171;
+    --bs-btn-bg: #05b171;
+    --bs-btn-border-color: #05b171;
+    --bs-btn-hover-bg: #049660;
+    --bs-btn-hover-border-color: #048e5a;
+    --bs-btn-focus-shadow-rgb: 43, 189, 134;
+    --bs-btn-active-bg: #048e5a;
+    --bs-btn-active-border-color: #048555;
+    --bs-btn-disabled-bg: #05b171;
+    --bs-btn-disabled-border-color: #05b171;
 }
+
 
 .btn-info {
-  --bs-btn-color: #fff;
-  --bs-btn-bg: #25c2e3;
-  --bs-btn-border-color: #25c2e3;
-  --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #1fa5c1;
-  --bs-btn-hover-border-color: #1e9bb6;
-  --bs-btn-focus-shadow-rgb: 70, 203, 231;
-  --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #1e9bb6;
-  --bs-btn-active-border-color: #1c92aa;
-  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #fff;
-  --bs-btn-disabled-bg: #25c2e3;
-  --bs-btn-disabled-border-color: #25c2e3;
+    --bs-btn-color: #fff;
+    --bs-btn-bg: #25c2e3;
+    --bs-btn-border-color: #25c2e3;
+    --bs-btn-hover-color: #fff;
+    --bs-btn-hover-bg: #1fa5c1;
+    --bs-btn-hover-border-color: #1e9bb6;
+    --bs-btn-focus-shadow-rgb: 70, 203, 231;
+    --bs-btn-active-color: #fff;
+    --bs-btn-active-bg: #1e9bb6;
+    --bs-btn-active-border-color: #1c92aa;
+    --bs-btn-disabled-color: #fff;
+    --bs-btn-disabled-bg: #25c2e3;
+    --bs-btn-disabled-border-color: #25c2e3;
 }
+
 
 .btn-warning {
-  --bs-btn-color: #000;
-  --bs-btn-bg: #faae42;
-  --bs-btn-border-color: #faae42;
-  --bs-btn-hover-color: #000;
-  --bs-btn-hover-bg: #fbba5e;
-  --bs-btn-hover-border-color: #fbb655;
-  --bs-btn-focus-shadow-rgb: 213, 148, 56;
-  --bs-btn-active-color: #000;
-  --bs-btn-active-bg: #fbbe68;
-  --bs-btn-active-border-color: #fbb655;
-  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #000;
-  --bs-btn-disabled-bg: #faae42;
-  --bs-btn-disabled-border-color: #faae42;
+    --bs-btn-bg: #faae42;
+    --bs-btn-border-color: #faae42;
+    --bs-btn-hover-bg: #fbba5e;
+    --bs-btn-hover-border-color: #fbb655;
+    --bs-btn-focus-shadow-rgb: 213, 148, 56;
+    --bs-btn-active-bg: #fbbe68;
+    --bs-btn-active-border-color: #fbb655;
+    --bs-btn-disabled-bg: #faae42;
+    --bs-btn-disabled-border-color: #faae42;
 }
+
 
 .btn-danger {
-  --bs-btn-color: #fff;
-  --bs-btn-bg: #ea4444;
-  --bs-btn-border-color: #ea4444;
-  --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #c73a3a;
-  --bs-btn-hover-border-color: #bb3636;
-  --bs-btn-focus-shadow-rgb: 237, 96, 96;
-  --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #bb3636;
-  --bs-btn-active-border-color: #b03333;
-  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #fff;
-  --bs-btn-disabled-bg: #ea4444;
-  --bs-btn-disabled-border-color: #ea4444;
+    --bs-btn-bg: #ea4444;
+    --bs-btn-border-color: #ea4444;
+    --bs-btn-hover-bg: #c73a3a;
+    --bs-btn-hover-border-color: #bb3636;
+    --bs-btn-focus-shadow-rgb: 237, 96, 96;
+    --bs-btn-active-bg: #bb3636;
+    --bs-btn-active-border-color: #b03333;
+    --bs-btn-disabled-bg: #ea4444;
+    --bs-btn-disabled-border-color: #ea4444;
 }
 
+
 .btn-light {
-  --bs-btn-color: #000;
-  --bs-btn-bg: #ededed;
-  --bs-btn-border-color: #ededed;
-  --bs-btn-hover-color: #000;
-  --bs-btn-hover-bg: #c9c9c9;
-  --bs-btn-hover-border-color: #bebebe;
-  --bs-btn-focus-shadow-rgb: 201, 201, 201;
-  --bs-btn-active-color: #000;
-  --bs-btn-active-bg: #bebebe;
-  --bs-btn-active-border-color: #b2b2b2;
-  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #000;
-  --bs-btn-disabled-bg: #ededed;
-  --bs-btn-disabled-border-color: #ededed;
+    --bs-btn-bg: #ededed;
+    --bs-btn-border-color: #ededed;
+    --bs-btn-hover-bg: #c9c9c9;
+    --bs-btn-hover-border-color: #bebebe;
+    --bs-btn-focus-shadow-rgb: 201, 201, 201;
+    --bs-btn-active-bg: #bebebe;
+    --bs-btn-active-border-color: #b2b2b2;
+    --bs-btn-disabled-bg: #ededed;
+    --bs-btn-disabled-border-color: #ededed;
 }
 
 .btn-dark {
-  --bs-btn-color: #fff;
-  --bs-btn-bg: #293134;
-  --bs-btn-border-color: #293134;
-  --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #495052;
-  --bs-btn-hover-border-color: #3e4648;
-  --bs-btn-focus-shadow-rgb: 73, 80, 82;
-  --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #545a5d;
-  --bs-btn-active-border-color: #3e4648;
-  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #fff;
-  --bs-btn-disabled-bg: #293134;
-  --bs-btn-disabled-border-color: #293134;
+    --bs-btn-bg: #293134;
+    --bs-btn-border-color: #293134;
+    --bs-btn-hover-bg: #495052;
+    --bs-btn-hover-border-color: #3e4648;
+    --bs-btn-focus-shadow-rgb: 73, 80, 82;
+    --bs-btn-active-bg: #545a5d;
+    --bs-btn-active-border-color: #3e4648;
+    --bs-btn-disabled-bg: #293134;
+    --bs-btn-disabled-border-color: #293134;
 }
 
+
 .btn-outline-primary {
-  --bs-btn-color: #5149e5;
-  --bs-btn-border-color: #5149e5;
-  --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #5149e5;
-  --bs-btn-hover-border-color: #5149e5;
-  --bs-btn-focus-shadow-rgb: 81, 73, 229;
-  --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #5149e5;
-  --bs-btn-active-border-color: #5149e5;
-  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #5149e5;
-  --bs-btn-disabled-bg: transparent;
-  --bs-btn-disabled-border-color: #5149e5;
-  --bs-gradient: none;
+    --bs-btn-color: #5149e5;
+    --bs-btn-border-color: #5149e5;
+    --bs-btn-hover-bg: #5149e5;
+    --bs-btn-hover-border-color: #5149e5;
+    --bs-btn-focus-shadow-rgb: 81, 73, 229;
+    --bs-btn-active-bg: #5149e5;
+    --bs-btn-active-border-color: #5149e5;
+    --bs-btn-disabled-color: #5149e5;
+    --bs-btn-disabled-border-color: #5149e5;
 }
 
 .btn-outline-secondary {
-  --bs-btn-color: #9932e7;
-  --bs-btn-border-color: #9932e7;
-  --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #9932e7;
-  --bs-btn-hover-border-color: #9932e7;
-  --bs-btn-focus-shadow-rgb: 153, 50, 231;
-  --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #9932e7;
-  --bs-btn-active-border-color: #9932e7;
-  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #9932e7;
-  --bs-btn-disabled-bg: transparent;
-  --bs-btn-disabled-border-color: #9932e7;
-  --bs-gradient: none;
+    --bs-btn-color: #9932e7;
+    --bs-btn-border-color: #9932e7;
+    --bs-btn-hover-bg: #9932e7;
+    --bs-btn-hover-border-color: #9932e7;
+    --bs-btn-focus-shadow-rgb: 153, 50, 231;
+    --bs-btn-active-bg: #9932e7;
+    --bs-btn-active-border-color: #9932e7;
+    --bs-btn-disabled-color: #9932e7;
+    --bs-btn-disabled-border-color: #9932e7;
 }
 
 .btn-outline-success {
-  --bs-btn-color: #05b171;
-  --bs-btn-border-color: #05b171;
-  --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #05b171;
-  --bs-btn-hover-border-color: #05b171;
-  --bs-btn-focus-shadow-rgb: 5, 177, 113;
-  --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #05b171;
-  --bs-btn-active-border-color: #05b171;
-  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #05b171;
-  --bs-btn-disabled-bg: transparent;
-  --bs-btn-disabled-border-color: #05b171;
-  --bs-gradient: none;
+    --bs-btn-color: #05b171;
+    --bs-btn-border-color: #05b171;
+    --bs-btn-hover-bg: #05b171;
+    --bs-btn-hover-border-color: #05b171;
+    --bs-btn-focus-shadow-rgb: 5, 177, 113;
+    --bs-btn-active-bg: #05b171;
+    --bs-btn-active-border-color: #05b171;
+    --bs-btn-disabled-color: #05b171;
+    --bs-btn-disabled-border-color: #05b171;
 }
 
 .btn-outline-info {
-  --bs-btn-color: #25c2e3;
-  --bs-btn-border-color: #25c2e3;
-  --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #25c2e3;
-  --bs-btn-hover-border-color: #25c2e3;
-  --bs-btn-focus-shadow-rgb: 37, 194, 227;
-  --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #25c2e3;
-  --bs-btn-active-border-color: #25c2e3;
-  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #25c2e3;
-  --bs-btn-disabled-bg: transparent;
-  --bs-btn-disabled-border-color: #25c2e3;
-  --bs-gradient: none;
+    --bs-btn-color: #25c2e3;
+    --bs-btn-border-color: #25c2e3;
+    --bs-btn-hover-color: #fff;
+    --bs-btn-hover-bg: #25c2e3;
+    --bs-btn-hover-border-color: #25c2e3;
+    --bs-btn-focus-shadow-rgb: 37, 194, 227;
+    --bs-btn-active-color: #fff;
+    --bs-btn-active-bg: #25c2e3;
+    --bs-btn-active-border-color: #25c2e3;
+    --bs-btn-disabled-color: #25c2e3;
+    --bs-btn-disabled-border-color: #25c2e3;
 }
 
 .btn-outline-warning {
-  --bs-btn-color: #faae42;
-  --bs-btn-border-color: #faae42;
-  --bs-btn-hover-color: #000;
-  --bs-btn-hover-bg: #faae42;
-  --bs-btn-hover-border-color: #faae42;
-  --bs-btn-focus-shadow-rgb: 250, 174, 66;
-  --bs-btn-active-color: #000;
-  --bs-btn-active-bg: #faae42;
-  --bs-btn-active-border-color: #faae42;
-  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #faae42;
-  --bs-btn-disabled-bg: transparent;
-  --bs-btn-disabled-border-color: #faae42;
-  --bs-gradient: none;
+    --bs-btn-color: #faae42;
+    --bs-btn-border-color: #faae42;
+    --bs-btn-hover-bg: #faae42;
+    --bs-btn-hover-border-color: #faae42;
+    --bs-btn-focus-shadow-rgb: 250, 174, 66;
+    --bs-btn-active-bg: #faae42;
+    --bs-btn-active-border-color: #faae42;
+    --bs-btn-disabled-color: #faae42;
+    --bs-btn-disabled-border-color: #faae42;
 }
 
 .btn-outline-danger {
-  --bs-btn-color: #ea4444;
-  --bs-btn-border-color: #ea4444;
-  --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #ea4444;
-  --bs-btn-hover-border-color: #ea4444;
-  --bs-btn-focus-shadow-rgb: 234, 68, 68;
-  --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #ea4444;
-  --bs-btn-active-border-color: #ea4444;
-  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #ea4444;
-  --bs-btn-disabled-bg: transparent;
-  --bs-btn-disabled-border-color: #ea4444;
-  --bs-gradient: none;
+    --bs-btn-color: #ea4444;
+    --bs-btn-border-color: #ea4444;
+    --bs-btn-hover-bg: #ea4444;
+    --bs-btn-hover-border-color: #ea4444;
+    --bs-btn-focus-shadow-rgb: 234, 68, 68;
+    --bs-btn-active-bg: #ea4444;
+    --bs-btn-active-border-color: #ea4444;
+    --bs-btn-disabled-color: #ea4444;
+    --bs-btn-disabled-border-color: #ea4444;
 }
 
 .btn-outline-light {
-  --bs-btn-color: #ededed;
-  --bs-btn-border-color: #ededed;
-  --bs-btn-hover-color: #000;
-  --bs-btn-hover-bg: #ededed;
-  --bs-btn-hover-border-color: #ededed;
-  --bs-btn-focus-shadow-rgb: 237, 237, 237;
-  --bs-btn-active-color: #000;
-  --bs-btn-active-bg: #ededed;
-  --bs-btn-active-border-color: #ededed;
-  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #ededed;
-  --bs-btn-disabled-bg: transparent;
-  --bs-btn-disabled-border-color: #ededed;
-  --bs-gradient: none;
+    --bs-btn-color: #ededed;
+    --bs-btn-border-color: #ededed;
+    --bs-btn-hover-bg: #ededed;
+    --bs-btn-hover-border-color: #ededed;
+    --bs-btn-focus-shadow-rgb: 237, 237, 237;
+    --bs-btn-active-bg: #ededed;
+    --bs-btn-active-border-color: #ededed;
+    --bs-btn-disabled-color: #ededed;
+    --bs-btn-disabled-border-color: #ededed;
 }
 
 .btn-outline-dark {
-  --bs-btn-color: #293134;
-  --bs-btn-border-color: #293134;
-  --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #293134;
-  --bs-btn-hover-border-color: #293134;
-  --bs-btn-focus-shadow-rgb: 41, 49, 52;
-  --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #293134;
-  --bs-btn-active-border-color: #293134;
-  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #293134;
-  --bs-btn-disabled-bg: transparent;
-  --bs-btn-disabled-border-color: #293134;
-  --bs-gradient: none;
+    --bs-btn-color: #293134;
+    --bs-btn-border-color: #293134;
+    --bs-btn-hover-bg: #293134;
+    --bs-btn-hover-border-color: #293134;
+    --bs-btn-focus-shadow-rgb: 41, 49, 52;
+    --bs-btn-active-bg: #293134;
+    --bs-btn-active-border-color: #293134;
+    --bs-btn-disabled-color: #293134;
+    --bs-btn-disabled-border-color: #293134;
 }
+
 
 .btn-link {
-  --bs-btn-font-weight: 400;
-  --bs-btn-color: var(--bs-link-color);
-  --bs-btn-bg: transparent;
-  --bs-btn-border-color: transparent;
-  --bs-btn-hover-color: var(--bs-link-hover-color);
-  --bs-btn-hover-border-color: transparent;
-  --bs-btn-active-color: var(--bs-link-hover-color);
-  --bs-btn-active-border-color: transparent;
-  --bs-btn-disabled-color: #6c757d;
-  --bs-btn-disabled-border-color: transparent;
-  --bs-btn-box-shadow: 0 0 0 #000;
-  --bs-btn-focus-shadow-rgb: 107, 100, 233;
-  text-decoration: underline;
-}
-.btn-link:focus-visible {
-  color: var(--bs-btn-color);
-}
-.btn-link:hover {
-  color: var(--bs-btn-hover-color);
+    --bs-btn-focus-shadow-rgb: 107, 100, 233;
 }
 
-.btn-lg, .btn-group-lg > .btn {
-  --bs-btn-padding-y: 1rem;
-  --bs-btn-padding-x: 1.5rem;
-  --bs-btn-font-size: 1.09375rem;
-  --bs-btn-border-radius: var(--bs-border-radius-lg);
+
+.btn-lg,
+.btn-group-lg>.btn {
+    --bs-btn-padding-y: 1rem;
+    --bs-btn-padding-x: 1.5rem;
+    --bs-btn-font-size: 1.09375rem;
 }
 
-.btn-sm, .btn-group-sm > .btn {
-  --bs-btn-padding-y: 0.25rem;
-  --bs-btn-padding-x: 0.5rem;
-  --bs-btn-font-size: 0.765625rem;
-  --bs-btn-border-radius: var(--bs-border-radius-sm);
+.btn-sm,
+.btn-group-sm>.btn {
+    --bs-btn-font-size: 0.765625rem;
 }
 
-.fade {
-  transition: opacity 0.15s linear;
-}
-@media (prefers-reduced-motion: reduce) {
-  .fade {
-    transition: none;
-  }
-}
-.fade:not(.show) {
-  opacity: 0;
-}
-
-.collapse:not(.show) {
-  display: none;
-}
-
-.collapsing {
-  height: 0;
-  overflow: hidden;
-  transition: height 0.35s ease;
-}
-@media (prefers-reduced-motion: reduce) {
-  .collapsing {
-    transition: none;
-  }
-}
-.collapsing.collapse-horizontal {
-  width: 0;
-  height: auto;
-  transition: width 0.35s ease;
-}
-@media (prefers-reduced-motion: reduce) {
-  .collapsing.collapse-horizontal {
-    transition: none;
-  }
-}
-
-.dropup,
-.dropend,
-.dropdown,
-.dropstart,
-.dropup-center,
-.dropdown-center {
-  position: relative;
-}
-
-.dropdown-toggle {
-  white-space: nowrap;
-}
-.dropdown-toggle::after {
-  display: inline-block;
-  margin-left: 0.255em;
-  vertical-align: 0.255em;
-  content: "";
-  border-top: 0.3em solid;
-  border-right: 0.3em solid transparent;
-  border-bottom: 0;
-  border-left: 0.3em solid transparent;
-}
-.dropdown-toggle:empty::after {
-  margin-left: 0;
-}
 
 .dropdown-menu {
-  --bs-dropdown-zindex: 1000;
-  --bs-dropdown-min-width: 10rem;
-  --bs-dropdown-padding-x: 0;
-  --bs-dropdown-padding-y: 0.5rem;
-  --bs-dropdown-spacer: 0.125rem;
-  --bs-dropdown-font-size: 0.875rem;
-  --bs-dropdown-color: var(--bs-body-color);
-  --bs-dropdown-bg: var(--bs-body-bg);
-  --bs-dropdown-border-color: var(--bs-border-color-translucent);
-  --bs-dropdown-border-radius: 0.5rem;
-  --bs-dropdown-border-width: var(--bs-border-width);
-  --bs-dropdown-inner-border-radius: calc(0.5rem - var(--bs-border-width));
-  --bs-dropdown-divider-bg: #e6e6e6;
-  --bs-dropdown-divider-margin-y: 0.5rem;
-  --bs-dropdown-box-shadow: var(--bs-box-shadow);
-  --bs-dropdown-link-color: var(--bs-body-color);
-  --bs-dropdown-link-hover-color: var(--bs-body-color);
-  --bs-dropdown-link-hover-bg: var(--bs-tertiary-bg);
-  --bs-dropdown-link-active-color: #fff;
-  --bs-dropdown-link-active-bg: #5149e5;
-  --bs-dropdown-link-disabled-color: var(--bs-tertiary-color);
-  --bs-dropdown-item-padding-x: 1rem;
-  --bs-dropdown-item-padding-y: 0.25rem;
-  --bs-dropdown-header-color: #6c757d;
-  --bs-dropdown-header-padding-x: 1rem;
-  --bs-dropdown-header-padding-y: 0.5rem;
-  position: absolute;
-  z-index: var(--bs-dropdown-zindex);
-  display: none;
-  min-width: var(--bs-dropdown-min-width);
-  padding: var(--bs-dropdown-padding-y) var(--bs-dropdown-padding-x);
-  margin: 0;
-  font-size: var(--bs-dropdown-font-size);
-  color: var(--bs-dropdown-color);
-  text-align: left;
-  list-style: none;
-  background-color: var(--bs-dropdown-bg);
-  background-clip: padding-box;
-  border: var(--bs-dropdown-border-width) solid var(--bs-dropdown-border-color);
-  border-radius: var(--bs-dropdown-border-radius);
-}
-.dropdown-menu[data-bs-popper] {
-  top: 100%;
-  left: 0;
-  margin-top: var(--bs-dropdown-spacer);
+    --bs-dropdown-font-size: 0.875rem;
+    --bs-dropdown-border-radius: 0.5rem;
+    --bs-dropdown-inner-border-radius: calc(0.5rem - var(--bs-border-width));
+    --bs-dropdown-divider-bg: #e6e6e6;
+    --bs-dropdown-link-active-bg: #5149e5;
 }
 
-.dropdown-menu-start {
-  --bs-position: start;
-}
-.dropdown-menu-start[data-bs-popper] {
-  right: auto;
-  left: 0;
-}
-
-.dropdown-menu-end {
-  --bs-position: end;
-}
-.dropdown-menu-end[data-bs-popper] {
-  right: 0;
-  left: auto;
-}
-
-@media (min-width: 576px) {
-  .dropdown-menu-sm-start {
-    --bs-position: start;
-  }
-  .dropdown-menu-sm-start[data-bs-popper] {
-    right: auto;
-    left: 0;
-  }
-  .dropdown-menu-sm-end {
-    --bs-position: end;
-  }
-  .dropdown-menu-sm-end[data-bs-popper] {
-    right: 0;
-    left: auto;
-  }
-}
-@media (min-width: 768px) {
-  .dropdown-menu-md-start {
-    --bs-position: start;
-  }
-  .dropdown-menu-md-start[data-bs-popper] {
-    right: auto;
-    left: 0;
-  }
-  .dropdown-menu-md-end {
-    --bs-position: end;
-  }
-  .dropdown-menu-md-end[data-bs-popper] {
-    right: 0;
-    left: auto;
-  }
-}
-@media (min-width: 992px) {
-  .dropdown-menu-lg-start {
-    --bs-position: start;
-  }
-  .dropdown-menu-lg-start[data-bs-popper] {
-    right: auto;
-    left: 0;
-  }
-  .dropdown-menu-lg-end {
-    --bs-position: end;
-  }
-  .dropdown-menu-lg-end[data-bs-popper] {
-    right: 0;
-    left: auto;
-  }
-}
-@media (min-width: 1200px) {
-  .dropdown-menu-xl-start {
-    --bs-position: start;
-  }
-  .dropdown-menu-xl-start[data-bs-popper] {
-    right: auto;
-    left: 0;
-  }
-  .dropdown-menu-xl-end {
-    --bs-position: end;
-  }
-  .dropdown-menu-xl-end[data-bs-popper] {
-    right: 0;
-    left: auto;
-  }
-}
-@media (min-width: 1400px) {
-  .dropdown-menu-xxl-start {
-    --bs-position: start;
-  }
-  .dropdown-menu-xxl-start[data-bs-popper] {
-    right: auto;
-    left: 0;
-  }
-  .dropdown-menu-xxl-end {
-    --bs-position: end;
-  }
-  .dropdown-menu-xxl-end[data-bs-popper] {
-    right: 0;
-    left: auto;
-  }
-}
-.dropup .dropdown-menu[data-bs-popper] {
-  top: auto;
-  bottom: 100%;
-  margin-top: 0;
-  margin-bottom: var(--bs-dropdown-spacer);
-}
-.dropup .dropdown-toggle::after {
-  display: inline-block;
-  margin-left: 0.255em;
-  vertical-align: 0.255em;
-  content: "";
-  border-top: 0;
-  border-right: 0.3em solid transparent;
-  border-bottom: 0.3em solid;
-  border-left: 0.3em solid transparent;
-}
-.dropup .dropdown-toggle:empty::after {
-  margin-left: 0;
-}
-
-.dropend .dropdown-menu[data-bs-popper] {
-  top: 0;
-  right: auto;
-  left: 100%;
-  margin-top: 0;
-  margin-left: var(--bs-dropdown-spacer);
-}
-.dropend .dropdown-toggle::after {
-  display: inline-block;
-  margin-left: 0.255em;
-  vertical-align: 0.255em;
-  content: "";
-  border-top: 0.3em solid transparent;
-  border-right: 0;
-  border-bottom: 0.3em solid transparent;
-  border-left: 0.3em solid;
-}
-.dropend .dropdown-toggle:empty::after {
-  margin-left: 0;
-}
-.dropend .dropdown-toggle::after {
-  vertical-align: 0;
-}
-
-.dropstart .dropdown-menu[data-bs-popper] {
-  top: 0;
-  right: 100%;
-  left: auto;
-  margin-top: 0;
-  margin-right: var(--bs-dropdown-spacer);
-}
-.dropstart .dropdown-toggle::after {
-  display: inline-block;
-  margin-left: 0.255em;
-  vertical-align: 0.255em;
-  content: "";
-}
-.dropstart .dropdown-toggle::after {
-  display: none;
-}
-.dropstart .dropdown-toggle::before {
-  display: inline-block;
-  margin-right: 0.255em;
-  vertical-align: 0.255em;
-  content: "";
-  border-top: 0.3em solid transparent;
-  border-right: 0.3em solid;
-  border-bottom: 0.3em solid transparent;
-}
-.dropstart .dropdown-toggle:empty::after {
-  margin-left: 0;
-}
-.dropstart .dropdown-toggle::before {
-  vertical-align: 0;
-}
-
-.dropdown-divider {
-  height: 0;
-  margin: var(--bs-dropdown-divider-margin-y) 0;
-  overflow: hidden;
-  border-top: 1px solid var(--bs-dropdown-divider-bg);
-  opacity: 1;
-}
-
-.dropdown-item {
-  display: block;
-  width: 100%;
-  padding: var(--bs-dropdown-item-padding-y) var(--bs-dropdown-item-padding-x);
-  clear: both;
-  font-weight: 400;
-  color: var(--bs-dropdown-link-color);
-  text-align: inherit;
-  text-decoration: none;
-  white-space: nowrap;
-  background-color: transparent;
-  border: 0;
-  border-radius: var(--bs-dropdown-item-border-radius, 0);
-}
-.dropdown-item:hover, .dropdown-item:focus {
-  color: var(--bs-dropdown-link-hover-color);
-  background-color: var(--bs-dropdown-link-hover-bg);
-}
-.dropdown-item.active, .dropdown-item:active {
-  color: var(--bs-dropdown-link-active-color);
-  text-decoration: none;
-  background-color: var(--bs-dropdown-link-active-bg);
-}
-.dropdown-item.disabled, .dropdown-item:disabled {
-  color: var(--bs-dropdown-link-disabled-color);
-  pointer-events: none;
-  background-color: transparent;
-}
-
-.dropdown-menu.show {
-  display: block;
-}
 
 .dropdown-header {
-  display: block;
-  padding: var(--bs-dropdown-header-padding-y) var(--bs-dropdown-header-padding-x);
-  margin-bottom: 0;
-  font-size: 0.765625rem;
-  color: var(--bs-dropdown-header-color);
-  white-space: nowrap;
-}
-
-.dropdown-item-text {
-  display: block;
-  padding: var(--bs-dropdown-item-padding-y) var(--bs-dropdown-item-padding-x);
-  color: var(--bs-dropdown-link-color);
+    font-size: 0.765625rem;
 }
 
 .dropdown-menu-dark {
-  --bs-dropdown-color: #dee2e6;
-  --bs-dropdown-bg: #343a40;
-  --bs-dropdown-border-color: var(--bs-border-color-translucent);
-  --bs-dropdown-box-shadow: ;
-  --bs-dropdown-link-color: #dee2e6;
-  --bs-dropdown-link-hover-color: #fff;
-  --bs-dropdown-divider-bg: #e6e6e6;
-  --bs-dropdown-link-hover-bg: rgba(255, 255, 255, 0.15);
-  --bs-dropdown-link-active-color: #fff;
-  --bs-dropdown-link-active-bg: #5149e5;
-  --bs-dropdown-link-disabled-color: #adb5bd;
-  --bs-dropdown-header-color: #adb5bd;
+    --bs-dropdown-divider-bg: #e6e6e6;
+    --bs-dropdown-link-active-bg: #5149e5;
 }
 
-.btn-group,
-.btn-group-vertical {
-  position: relative;
-  display: inline-flex;
-  vertical-align: middle;
-}
-.btn-group > .btn,
-.btn-group-vertical > .btn {
-  position: relative;
-  flex: 1 1 auto;
-}
-.btn-group > .btn-check:checked + .btn,
-.btn-group > .btn-check:focus + .btn,
-.btn-group > .btn:hover,
-.btn-group > .btn:focus,
-.btn-group > .btn:active,
-.btn-group > .btn.active,
-.btn-group-vertical > .btn-check:checked + .btn,
-.btn-group-vertical > .btn-check:focus + .btn,
-.btn-group-vertical > .btn:hover,
-.btn-group-vertical > .btn:focus,
-.btn-group-vertical > .btn:active,
-.btn-group-vertical > .btn.active {
-  z-index: 1;
-}
-
-.btn-toolbar {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-start;
-}
-.btn-toolbar .input-group {
-  width: auto;
-}
-
-.btn-group {
-  border-radius: var(--bs-border-radius);
-}
-.btn-group > :not(.btn-check:first-child) + .btn,
-.btn-group > .btn-group:not(:first-child) {
-  margin-left: calc(var(--bs-border-width) * -1);
-}
-.btn-group > .btn:not(:last-child):not(.dropdown-toggle),
-.btn-group > .btn.dropdown-toggle-split:first-child,
-.btn-group > .btn-group:not(:last-child) > .btn {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-.btn-group > .btn:nth-child(n+3),
-.btn-group > :not(.btn-check) + .btn,
-.btn-group > .btn-group:not(:first-child) > .btn {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-}
 
 .dropdown-toggle-split {
-  padding-right: 0.9375rem;
-  padding-left: 0.9375rem;
-}
-.dropdown-toggle-split::after, .dropup .dropdown-toggle-split::after, .dropend .dropdown-toggle-split::after {
-  margin-left: 0;
-}
-.dropstart .dropdown-toggle-split::before {
-  margin-right: 0;
+    padding-right: 0.9375rem;
+    padding-left: 0.9375rem;
 }
 
-.btn-sm + .dropdown-toggle-split, .btn-group-sm > .btn + .dropdown-toggle-split {
-  padding-right: 0.375rem;
-  padding-left: 0.375rem;
+
+.btn-lg+.dropdown-toggle-split,
+.btn-group-lg>.btn+.dropdown-toggle-split {
+    padding-right: 1.125rem;
+    padding-left: 1.125rem;
 }
 
-.btn-lg + .dropdown-toggle-split, .btn-group-lg > .btn + .dropdown-toggle-split {
-  padding-right: 1.125rem;
-  padding-left: 1.125rem;
-}
-
-.btn-group-vertical {
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: center;
-}
-.btn-group-vertical > .btn,
-.btn-group-vertical > .btn-group {
-  width: 100%;
-}
-.btn-group-vertical > .btn:not(:first-child),
-.btn-group-vertical > .btn-group:not(:first-child) {
-  margin-top: calc(var(--bs-border-width) * -1);
-}
-.btn-group-vertical > .btn:not(:last-child):not(.dropdown-toggle),
-.btn-group-vertical > .btn-group:not(:last-child) > .btn {
-  border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0;
-}
-.btn-group-vertical > .btn ~ .btn,
-.btn-group-vertical > .btn-group:not(:first-child) > .btn {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-}
-
-.nav {
-  --bs-nav-link-padding-x: 1rem;
-  --bs-nav-link-padding-y: 0.5rem;
-  --bs-nav-link-font-weight: ;
-  --bs-nav-link-color: var(--bs-link-color);
-  --bs-nav-link-hover-color: var(--bs-link-hover-color);
-  --bs-nav-link-disabled-color: var(--bs-secondary-color);
-  display: flex;
-  flex-wrap: wrap;
-  padding-left: 0;
-  margin-bottom: 0;
-  list-style: none;
-}
-
-.nav-link {
-  display: block;
-  padding: var(--bs-nav-link-padding-y) var(--bs-nav-link-padding-x);
-  font-size: var(--bs-nav-link-font-size);
-  font-weight: var(--bs-nav-link-font-weight);
-  color: var(--bs-nav-link-color);
-  text-decoration: none;
-  background: none;
-  border: 0;
-  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out;
-}
-@media (prefers-reduced-motion: reduce) {
-  .nav-link {
-    transition: none;
-  }
-}
-.nav-link:hover, .nav-link:focus {
-  color: var(--bs-nav-link-hover-color);
-}
 .nav-link:focus-visible {
-  outline: 0;
-  box-shadow: 0 0 0 0.25rem rgba(81, 73, 229, 0.25);
-}
-.nav-link.disabled, .nav-link:disabled {
-  color: var(--bs-nav-link-disabled-color);
-  pointer-events: none;
-  cursor: default;
+    box-shadow: 0 0 0 0.25rem rgba(81, 73, 229, 0.25);
 }
 
-.nav-tabs {
-  --bs-nav-tabs-border-width: var(--bs-border-width);
-  --bs-nav-tabs-border-color: var(--bs-border-color);
-  --bs-nav-tabs-border-radius: var(--bs-border-radius);
-  --bs-nav-tabs-link-hover-border-color: var(--bs-secondary-bg) var(--bs-secondary-bg) var(--bs-border-color);
-  --bs-nav-tabs-link-active-color: var(--bs-emphasis-color);
-  --bs-nav-tabs-link-active-bg: var(--bs-body-bg);
-  --bs-nav-tabs-link-active-border-color: var(--bs-border-color) var(--bs-border-color) var(--bs-body-bg);
-  border-bottom: var(--bs-nav-tabs-border-width) solid var(--bs-nav-tabs-border-color);
-}
-.nav-tabs .nav-link {
-  margin-bottom: calc(-1 * var(--bs-nav-tabs-border-width));
-  border: var(--bs-nav-tabs-border-width) solid transparent;
-  border-top-left-radius: var(--bs-nav-tabs-border-radius);
-  border-top-right-radius: var(--bs-nav-tabs-border-radius);
-}
-.nav-tabs .nav-link:hover, .nav-tabs .nav-link:focus {
-  isolation: isolate;
-  border-color: var(--bs-nav-tabs-link-hover-border-color);
-}
-.nav-tabs .nav-link.active,
-.nav-tabs .nav-item.show .nav-link {
-  color: var(--bs-nav-tabs-link-active-color);
-  background-color: var(--bs-nav-tabs-link-active-bg);
-  border-color: var(--bs-nav-tabs-link-active-border-color);
-}
-.nav-tabs .dropdown-menu {
-  margin-top: calc(-1 * var(--bs-nav-tabs-border-width));
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-}
 
 .nav-pills {
-  --bs-nav-pills-border-radius: var(--bs-border-radius);
-  --bs-nav-pills-link-active-color: #fff;
-  --bs-nav-pills-link-active-bg: #5149e5;
-}
-.nav-pills .nav-link {
-  border-radius: var(--bs-nav-pills-border-radius);
-}
-.nav-pills .nav-link.active,
-.nav-pills .show > .nav-link {
-  color: var(--bs-nav-pills-link-active-color);
-  background-color: var(--bs-nav-pills-link-active-bg);
+    --bs-nav-pills-link-active-bg: #5149e5;
 }
 
-.nav-underline {
-  --bs-nav-underline-gap: 1rem;
-  --bs-nav-underline-border-width: 0.125rem;
-  --bs-nav-underline-link-active-color: var(--bs-emphasis-color);
-  gap: var(--bs-nav-underline-gap);
-}
-.nav-underline .nav-link {
-  padding-right: 0;
-  padding-left: 0;
-  border-bottom: var(--bs-nav-underline-border-width) solid transparent;
-}
-.nav-underline .nav-link:hover, .nav-underline .nav-link:focus {
-  border-bottom-color: currentcolor;
-}
-.nav-underline .nav-link.active,
-.nav-underline .show > .nav-link {
-  font-weight: 700;
-  color: var(--bs-nav-underline-link-active-color);
-  border-bottom-color: currentcolor;
-}
-
-.nav-fill > .nav-link,
-.nav-fill .nav-item {
-  flex: 1 1 auto;
-  text-align: center;
-}
-
-.nav-justified > .nav-link,
-.nav-justified .nav-item {
-  flex-basis: 0;
-  flex-grow: 1;
-  text-align: center;
-}
-
-.nav-fill .nav-item .nav-link,
-.nav-justified .nav-item .nav-link {
-  width: 100%;
-}
-
-.tab-content > .tab-pane {
-  display: none;
-}
-.tab-content > .active {
-  display: block;
-}
 
 .navbar {
-  --bs-navbar-padding-x: 0;
-  --bs-navbar-padding-y: 0.5rem;
-  --bs-navbar-color: rgba(var(--bs-emphasis-color-rgb), 0.65);
-  --bs-navbar-hover-color: rgba(var(--bs-emphasis-color-rgb), 0.8);
-  --bs-navbar-disabled-color: rgba(var(--bs-emphasis-color-rgb), 0.3);
-  --bs-navbar-active-color: rgba(var(--bs-emphasis-color-rgb), 1);
-  --bs-navbar-brand-padding-y: 0.3359375rem;
-  --bs-navbar-brand-margin-end: 1rem;
-  --bs-navbar-brand-font-size: 1.09375rem;
-  --bs-navbar-brand-color: rgba(var(--bs-emphasis-color-rgb), 1);
-  --bs-navbar-brand-hover-color: rgba(var(--bs-emphasis-color-rgb), 1);
-  --bs-navbar-nav-link-padding-x: 0.5rem;
-  --bs-navbar-toggler-padding-y: 0.25rem;
-  --bs-navbar-toggler-padding-x: 0.75rem;
-  --bs-navbar-toggler-font-size: 1.09375rem;
-  --bs-navbar-toggler-icon-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%2833, 37, 41, 0.75%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
-  --bs-navbar-toggler-border-color: rgba(var(--bs-emphasis-color-rgb), 0.15);
-  --bs-navbar-toggler-border-radius: var(--bs-border-radius);
-  --bs-navbar-toggler-focus-width: 0.25rem;
-  --bs-navbar-toggler-transition: box-shadow 0.15s ease-in-out;
-  position: relative;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--bs-navbar-padding-y) var(--bs-navbar-padding-x);
-}
-.navbar > .container,
-.navbar > .container-fluid,
-.navbar > .container-sm,
-.navbar > .container-md,
-.navbar > .container-lg,
-.navbar > .container-xl,
-.navbar > .container-xxl {
-  display: flex;
-  flex-wrap: inherit;
-  align-items: center;
-  justify-content: space-between;
-}
-.navbar-brand {
-  padding-top: var(--bs-navbar-brand-padding-y);
-  padding-bottom: var(--bs-navbar-brand-padding-y);
-  margin-right: var(--bs-navbar-brand-margin-end);
-  font-size: var(--bs-navbar-brand-font-size);
-  color: var(--bs-navbar-brand-color);
-  text-decoration: none;
-  white-space: nowrap;
-}
-.navbar-brand:hover, .navbar-brand:focus {
-  color: var(--bs-navbar-brand-hover-color);
+    --bs-navbar-brand-padding-y: 0.3359375rem;
+    --bs-navbar-brand-font-size: 1.09375rem;
+    --bs-navbar-toggler-font-size: 1.09375rem;
 }
 
-.navbar-nav {
-  --bs-nav-link-padding-x: 0;
-  --bs-nav-link-padding-y: 0.5rem;
-  --bs-nav-link-font-weight: ;
-  --bs-nav-link-color: var(--bs-navbar-color);
-  --bs-nav-link-hover-color: var(--bs-navbar-hover-color);
-  --bs-nav-link-disabled-color: var(--bs-navbar-disabled-color);
-  display: flex;
-  flex-direction: column;
-  padding-left: 0;
-  margin-bottom: 0;
-  list-style: none;
-}
-.navbar-nav .nav-link.active, .navbar-nav .nav-link.show {
-  color: var(--bs-navbar-active-color);
-}
-.navbar-nav .dropdown-menu {
-  position: static;
-}
-
-.navbar-text {
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-  color: var(--bs-navbar-color);
-}
-.navbar-text a,
-.navbar-text a:hover,
-.navbar-text a:focus {
-  color: var(--bs-navbar-active-color);
-}
-
-.navbar-collapse {
-  flex-basis: 100%;
-  flex-grow: 1;
-  align-items: center;
-}
-
-.navbar-toggler {
-  padding: var(--bs-navbar-toggler-padding-y) var(--bs-navbar-toggler-padding-x);
-  font-size: var(--bs-navbar-toggler-font-size);
-  line-height: 1;
-  color: var(--bs-navbar-color);
-  background-color: transparent;
-  border: var(--bs-border-width) solid var(--bs-navbar-toggler-border-color);
-  border-radius: var(--bs-navbar-toggler-border-radius);
-  transition: var(--bs-navbar-toggler-transition);
-}
-@media (prefers-reduced-motion: reduce) {
-  .navbar-toggler {
-    transition: none;
-  }
-}
-.navbar-toggler:hover {
-  text-decoration: none;
-}
-.navbar-toggler:focus {
-  text-decoration: none;
-  outline: 0;
-  box-shadow: 0 0 0 var(--bs-navbar-toggler-focus-width);
-}
-
-.navbar-toggler-icon {
-  display: inline-block;
-  width: 1.5em;
-  height: 1.5em;
-  vertical-align: middle;
-  background-image: var(--bs-navbar-toggler-icon-bg);
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: 100%;
-}
-
-.navbar-nav-scroll {
-  max-height: var(--bs-scroll-height, 75vh);
-  overflow-y: auto;
-}
-
-@media (min-width: 576px) {
-  .navbar-expand-sm {
-    flex-wrap: nowrap;
-    justify-content: flex-start;
-  }
-  .navbar-expand-sm .navbar-nav {
-    flex-direction: row;
-  }
-  .navbar-expand-sm .navbar-nav .dropdown-menu {
-    position: absolute;
-  }
-  .navbar-expand-sm .navbar-nav .nav-link {
-    padding-right: var(--bs-navbar-nav-link-padding-x);
-    padding-left: var(--bs-navbar-nav-link-padding-x);
-  }
-  .navbar-expand-sm .navbar-nav-scroll {
-    overflow: visible;
-  }
-  .navbar-expand-sm .navbar-collapse {
-    display: flex !important;
-    flex-basis: auto;
-  }
-  .navbar-expand-sm .navbar-toggler {
-    display: none;
-  }
-  .navbar-expand-sm .offcanvas {
-    position: static;
-    z-index: auto;
-    flex-grow: 1;
-    width: auto !important;
-    height: auto !important;
-    visibility: visible !important;
-    background-color: transparent !important;
-    border: 0 !important;
-    transform: none !important;
-    transition: none;
-  }
-  .navbar-expand-sm .offcanvas .offcanvas-header {
-    display: none;
-  }
-  .navbar-expand-sm .offcanvas .offcanvas-body {
-    display: flex;
-    flex-grow: 0;
-    padding: 0;
-    overflow-y: visible;
-  }
-}
-@media (min-width: 768px) {
-  .navbar-expand-md {
-    flex-wrap: nowrap;
-    justify-content: flex-start;
-  }
-  .navbar-expand-md .navbar-nav {
-    flex-direction: row;
-  }
-  .navbar-expand-md .navbar-nav .dropdown-menu {
-    position: absolute;
-  }
-  .navbar-expand-md .navbar-nav .nav-link {
-    padding-right: var(--bs-navbar-nav-link-padding-x);
-    padding-left: var(--bs-navbar-nav-link-padding-x);
-  }
-  .navbar-expand-md .navbar-nav-scroll {
-    overflow: visible;
-  }
-  .navbar-expand-md .navbar-collapse {
-    display: flex !important;
-    flex-basis: auto;
-  }
-  .navbar-expand-md .navbar-toggler {
-    display: none;
-  }
-  .navbar-expand-md .offcanvas {
-    position: static;
-    z-index: auto;
-    flex-grow: 1;
-    width: auto !important;
-    height: auto !important;
-    visibility: visible !important;
-    background-color: transparent !important;
-    border: 0 !important;
-    transform: none !important;
-    transition: none;
-  }
-  .navbar-expand-md .offcanvas .offcanvas-header {
-    display: none;
-  }
-  .navbar-expand-md .offcanvas .offcanvas-body {
-    display: flex;
-    flex-grow: 0;
-    padding: 0;
-    overflow-y: visible;
-  }
-}
-@media (min-width: 992px) {
-  .navbar-expand-lg {
-    flex-wrap: nowrap;
-    justify-content: flex-start;
-  }
-  .navbar-expand-lg .navbar-nav {
-    flex-direction: row;
-  }
-  .navbar-expand-lg .navbar-nav .dropdown-menu {
-    position: absolute;
-  }
-  .navbar-expand-lg .navbar-nav .nav-link {
-    padding-right: var(--bs-navbar-nav-link-padding-x);
-    padding-left: var(--bs-navbar-nav-link-padding-x);
-  }
-  .navbar-expand-lg .navbar-nav-scroll {
-    overflow: visible;
-  }
-  .navbar-expand-lg .navbar-collapse {
-    display: flex !important;
-    flex-basis: auto;
-  }
-  .navbar-expand-lg .navbar-toggler {
-    display: none;
-  }
-  .navbar-expand-lg .offcanvas {
-    position: static;
-    z-index: auto;
-    flex-grow: 1;
-    width: auto !important;
-    height: auto !important;
-    visibility: visible !important;
-    background-color: transparent !important;
-    border: 0 !important;
-    transform: none !important;
-    transition: none;
-  }
-  .navbar-expand-lg .offcanvas .offcanvas-header {
-    display: none;
-  }
-  .navbar-expand-lg .offcanvas .offcanvas-body {
-    display: flex;
-    flex-grow: 0;
-    padding: 0;
-    overflow-y: visible;
-  }
-}
-@media (min-width: 1200px) {
-  .navbar-expand-xl {
-    flex-wrap: nowrap;
-    justify-content: flex-start;
-  }
-  .navbar-expand-xl .navbar-nav {
-    flex-direction: row;
-  }
-  .navbar-expand-xl .navbar-nav .dropdown-menu {
-    position: absolute;
-  }
-  .navbar-expand-xl .navbar-nav .nav-link {
-    padding-right: var(--bs-navbar-nav-link-padding-x);
-    padding-left: var(--bs-navbar-nav-link-padding-x);
-  }
-  .navbar-expand-xl .navbar-nav-scroll {
-    overflow: visible;
-  }
-  .navbar-expand-xl .navbar-collapse {
-    display: flex !important;
-    flex-basis: auto;
-  }
-  .navbar-expand-xl .navbar-toggler {
-    display: none;
-  }
-  .navbar-expand-xl .offcanvas {
-    position: static;
-    z-index: auto;
-    flex-grow: 1;
-    width: auto !important;
-    height: auto !important;
-    visibility: visible !important;
-    background-color: transparent !important;
-    border: 0 !important;
-    transform: none !important;
-    transition: none;
-  }
-  .navbar-expand-xl .offcanvas .offcanvas-header {
-    display: none;
-  }
-  .navbar-expand-xl .offcanvas .offcanvas-body {
-    display: flex;
-    flex-grow: 0;
-    padding: 0;
-    overflow-y: visible;
-  }
-}
-@media (min-width: 1400px) {
-  .navbar-expand-xxl {
-    flex-wrap: nowrap;
-    justify-content: flex-start;
-  }
-  .navbar-expand-xxl .navbar-nav {
-    flex-direction: row;
-  }
-  .navbar-expand-xxl .navbar-nav .dropdown-menu {
-    position: absolute;
-  }
-  .navbar-expand-xxl .navbar-nav .nav-link {
-    padding-right: var(--bs-navbar-nav-link-padding-x);
-    padding-left: var(--bs-navbar-nav-link-padding-x);
-  }
-  .navbar-expand-xxl .navbar-nav-scroll {
-    overflow: visible;
-  }
-  .navbar-expand-xxl .navbar-collapse {
-    display: flex !important;
-    flex-basis: auto;
-  }
-  .navbar-expand-xxl .navbar-toggler {
-    display: none;
-  }
-  .navbar-expand-xxl .offcanvas {
-    position: static;
-    z-index: auto;
-    flex-grow: 1;
-    width: auto !important;
-    height: auto !important;
-    visibility: visible !important;
-    background-color: transparent !important;
-    border: 0 !important;
-    transform: none !important;
-    transition: none;
-  }
-  .navbar-expand-xxl .offcanvas .offcanvas-header {
-    display: none;
-  }
-  .navbar-expand-xxl .offcanvas .offcanvas-body {
-    display: flex;
-    flex-grow: 0;
-    padding: 0;
-    overflow-y: visible;
-  }
-}
-.navbar-expand {
-  flex-wrap: nowrap;
-  justify-content: flex-start;
-}
-.navbar-expand .navbar-nav {
-  flex-direction: row;
-}
-.navbar-expand .navbar-nav .dropdown-menu {
-  position: absolute;
-}
-.navbar-expand .navbar-nav .nav-link {
-  padding-right: var(--bs-navbar-nav-link-padding-x);
-  padding-left: var(--bs-navbar-nav-link-padding-x);
-}
-.navbar-expand .navbar-nav-scroll {
-  overflow: visible;
-}
-.navbar-expand .navbar-collapse {
-  display: flex !important;
-  flex-basis: auto;
-}
-.navbar-expand .navbar-toggler {
-  display: none;
-}
-.navbar-expand .offcanvas {
-  position: static;
-  z-index: auto;
-  flex-grow: 1;
-  width: auto !important;
-  height: auto !important;
-  visibility: visible !important;
-  background-color: transparent !important;
-  border: 0 !important;
-  transform: none !important;
-  transition: none;
-}
-.navbar-expand .offcanvas .offcanvas-header {
-  display: none;
-}
-.navbar-expand .offcanvas .offcanvas-body {
-  display: flex;
-  flex-grow: 0;
-  padding: 0;
-  overflow-y: visible;
-}
-
-.navbar-dark,
-.navbar[data-bs-theme=dark] {
-  --bs-navbar-color: rgba(255, 255, 255, 0.55);
-  --bs-navbar-hover-color: rgba(255, 255, 255, 0.75);
-  --bs-navbar-disabled-color: rgba(255, 255, 255, 0.25);
-  --bs-navbar-active-color: #fff;
-  --bs-navbar-brand-color: #fff;
-  --bs-navbar-brand-hover-color: #fff;
-  --bs-navbar-toggler-border-color: rgba(255, 255, 255, 0.1);
-  --bs-navbar-toggler-icon-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%28255, 255, 255, 0.55%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
-}
-
-[data-bs-theme=dark] .navbar-toggler-icon {
-  --bs-navbar-toggler-icon-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%28255, 255, 255, 0.55%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
-}
 
 .card {
-  --bs-card-spacer-y: 1.5rem;
-  --bs-card-spacer-x: 1.5rem;
-  --bs-card-title-spacer-y: 0.5rem;
-  --bs-card-title-color: ;
-  --bs-card-subtitle-color: ;
-  --bs-card-border-width: var(--bs-border-width);
-  --bs-card-border-color: var(--bs-border-color-translucent);
-  --bs-card-border-radius: 1rem;
-  --bs-card-box-shadow: ;
-  --bs-card-inner-border-radius: calc(1rem - (var(--bs-border-width)));
-  --bs-card-cap-padding-y: 0.75rem;
-  --bs-card-cap-padding-x: 1.5rem;
-  --bs-card-cap-bg: rgba(var(--bs-body-color-rgb), 0.03);
-  --bs-card-cap-color: ;
-  --bs-card-height: ;
-  --bs-card-color: ;
-  --bs-card-bg: var(--bs-body-bg);
-  --bs-card-img-overlay-padding: 1rem;
-  --bs-card-group-margin: 0.75rem;
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  height: var(--bs-card-height);
-  color: var(--bs-body-color);
-  word-wrap: break-word;
-  background-color: var(--bs-card-bg);
-  background-clip: border-box;
-  border: var(--bs-card-border-width) solid var(--bs-card-border-color);
-  border-radius: var(--bs-card-border-radius);
-}
-.card > hr {
-  margin-right: 0;
-  margin-left: 0;
-}
-.card > .list-group {
-  border-top: inherit;
-  border-bottom: inherit;
-}
-.card > .list-group:first-child {
-  border-top-width: 0;
-  border-top-left-radius: var(--bs-card-inner-border-radius);
-  border-top-right-radius: var(--bs-card-inner-border-radius);
-}
-.card > .list-group:last-child {
-  border-bottom-width: 0;
-  border-bottom-right-radius: var(--bs-card-inner-border-radius);
-  border-bottom-left-radius: var(--bs-card-inner-border-radius);
-}
-.card > .card-header + .list-group,
-.card > .list-group + .card-footer {
-  border-top: 0;
+    --bs-card-spacer-y: 1.5rem;
+    --bs-card-spacer-x: 1.5rem;
+    --bs-card-border-radius: 1rem;
+    --bs-card-inner-border-radius: calc(1rem - (var(--bs-border-width)));
+    --bs-card-cap-padding-y: 0.75rem;
+    --bs-card-cap-padding-x: 1.5rem;
 }
 
-.card-body {
-  flex: 1 1 auto;
-  padding: var(--bs-card-spacer-y) var(--bs-card-spacer-x);
-  color: var(--bs-card-color);
-}
-
-.card-title {
-  margin-bottom: var(--bs-card-title-spacer-y);
-  color: var(--bs-card-title-color);
-}
-
-.card-subtitle {
-  margin-top: calc(-0.5 * var(--bs-card-title-spacer-y));
-  margin-bottom: 0;
-  color: var(--bs-card-subtitle-color);
-}
-
-.card-text:last-child {
-  margin-bottom: 0;
-}
-
-.card-link + .card-link {
-  margin-left: var(--bs-card-spacer-x);
-}
-
-.card-header {
-  padding: var(--bs-card-cap-padding-y) var(--bs-card-cap-padding-x);
-  margin-bottom: 0;
-  color: var(--bs-card-cap-color);
-  background-color: var(--bs-card-cap-bg);
-  border-bottom: var(--bs-card-border-width) solid var(--bs-card-border-color);
-}
-.card-header:first-child {
-  border-radius: var(--bs-card-inner-border-radius) var(--bs-card-inner-border-radius) 0 0;
-}
-
-.card-footer {
-  padding: var(--bs-card-cap-padding-y) var(--bs-card-cap-padding-x);
-  color: var(--bs-card-cap-color);
-  background-color: var(--bs-card-cap-bg);
-  border-top: var(--bs-card-border-width) solid var(--bs-card-border-color);
-}
-.card-footer:last-child {
-  border-radius: 0 0 var(--bs-card-inner-border-radius) var(--bs-card-inner-border-radius);
-}
-
-.card-header-tabs {
-  margin-right: calc(-0.5 * var(--bs-card-cap-padding-x));
-  margin-bottom: calc(-1 * var(--bs-card-cap-padding-y));
-  margin-left: calc(-0.5 * var(--bs-card-cap-padding-x));
-  border-bottom: 0;
-}
-.card-header-tabs .nav-link.active {
-  background-color: var(--bs-card-bg);
-  border-bottom-color: var(--bs-card-bg);
-}
-
-.card-header-pills {
-  margin-right: calc(-0.5 * var(--bs-card-cap-padding-x));
-  margin-left: calc(-0.5 * var(--bs-card-cap-padding-x));
-}
-
-.card-img-overlay {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  padding: var(--bs-card-img-overlay-padding);
-  border-radius: var(--bs-card-inner-border-radius);
-}
-
-.card-img,
-.card-img-top,
-.card-img-bottom {
-  width: 100%;
-}
-
-.card-img,
-.card-img-top {
-  border-top-left-radius: var(--bs-card-inner-border-radius);
-  border-top-right-radius: var(--bs-card-inner-border-radius);
-}
-
-.card-img,
-.card-img-bottom {
-  border-bottom-right-radius: var(--bs-card-inner-border-radius);
-  border-bottom-left-radius: var(--bs-card-inner-border-radius);
-}
-
-.card-group > .card {
-  margin-bottom: var(--bs-card-group-margin);
-}
-@media (min-width: 576px) {
-  .card-group {
-    display: flex;
-    flex-flow: row wrap;
-  }
-  .card-group > .card {
-    flex: 1 0 0%;
-    margin-bottom: 0;
-  }
-  .card-group > .card + .card {
-    margin-left: 0;
-    border-left: 0;
-  }
-  .card-group > .card:not(:last-child) {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-  }
-  .card-group > .card:not(:last-child) .card-img-top,
-  .card-group > .card:not(:last-child) .card-header {
-    border-top-right-radius: 0;
-  }
-  .card-group > .card:not(:last-child) .card-img-bottom,
-  .card-group > .card:not(:last-child) .card-footer {
-    border-bottom-right-radius: 0;
-  }
-  .card-group > .card:not(:first-child) {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-  }
-  .card-group > .card:not(:first-child) .card-img-top,
-  .card-group > .card:not(:first-child) .card-header {
-    border-top-left-radius: 0;
-  }
-  .card-group > .card:not(:first-child) .card-img-bottom,
-  .card-group > .card:not(:first-child) .card-footer {
-    border-bottom-left-radius: 0;
-  }
-}
 
 .accordion {
-  --bs-accordion-color: var(--bs-body-color);
-  --bs-accordion-bg: var(--bs-body-bg);
-  --bs-accordion-transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out, border-radius 0.15s ease;
-  --bs-accordion-border-color: var(--bs-border-color);
-  --bs-accordion-border-width: var(--bs-border-width);
-  --bs-accordion-border-radius: var(--bs-border-radius);
-  --bs-accordion-inner-border-radius: calc(var(--bs-border-radius) - (var(--bs-border-width)));
-  --bs-accordion-btn-padding-x: 1.25rem;
-  --bs-accordion-btn-padding-y: 1rem;
-  --bs-accordion-btn-color: var(--bs-body-color);
-  --bs-accordion-btn-bg: var(--bs-accordion-bg);
-  --bs-accordion-btn-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23212529'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
-  --bs-accordion-btn-icon-width: 1.25rem;
-  --bs-accordion-btn-icon-transform: rotate(-180deg);
-  --bs-accordion-btn-icon-transition: transform 0.2s ease-in-out;
-  --bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23201d5c'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
-  --bs-accordion-btn-focus-border-color: #a8a4f2;
-  --bs-accordion-btn-focus-box-shadow: 0 0 0 1px #5149e5;
-  --bs-accordion-body-padding-x: 1.25rem;
-  --bs-accordion-body-padding-y: 1rem;
-  --bs-accordion-active-color: var(--bs-primary-text-emphasis);
-  --bs-accordion-active-bg: var(--bs-primary-bg-subtle);
+    --bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23201d5c'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
+    --bs-accordion-btn-focus-border-color: #a8a4f2;
+    --bs-accordion-btn-focus-box-shadow: 0 0 0 1px #5149e5;
 }
 
 .accordion-button {
-  position: relative;
-  display: flex;
-  align-items: center;
-  width: 100%;
-  padding: var(--bs-accordion-btn-padding-y) var(--bs-accordion-btn-padding-x);
-  font-size: 0.875rem;
-  color: var(--bs-accordion-btn-color);
-  text-align: left;
-  background-color: var(--bs-accordion-btn-bg);
-  border: 0;
-  border-radius: 0;
-  overflow-anchor: none;
-  transition: var(--bs-accordion-transition);
-}
-@media (prefers-reduced-motion: reduce) {
-  .accordion-button {
-    transition: none;
-  }
-}
-.accordion-button:not(.collapsed) {
-  color: var(--bs-accordion-active-color);
-  background-color: var(--bs-accordion-active-bg);
-  box-shadow: inset 0 calc(-1 * var(--bs-accordion-border-width)) 0 var(--bs-accordion-border-color);
-}
-.accordion-button:not(.collapsed)::after {
-  background-image: var(--bs-accordion-btn-active-icon);
-  transform: var(--bs-accordion-btn-icon-transform);
-}
-.accordion-button::after {
-  flex-shrink: 0;
-  width: var(--bs-accordion-btn-icon-width);
-  height: var(--bs-accordion-btn-icon-width);
-  margin-left: auto;
-  content: "";
-  background-image: var(--bs-accordion-btn-icon);
-  background-repeat: no-repeat;
-  background-size: var(--bs-accordion-btn-icon-width);
-  transition: var(--bs-accordion-btn-icon-transition);
-}
-@media (prefers-reduced-motion: reduce) {
-  .accordion-button::after {
-    transition: none;
-  }
-}
-.accordion-button:hover {
-  z-index: 2;
-}
-.accordion-button:focus {
-  z-index: 3;
-  border-color: var(--bs-accordion-btn-focus-border-color);
-  outline: 0;
-  box-shadow: var(--bs-accordion-btn-focus-box-shadow);
-}
-
-.accordion-header {
-  margin-bottom: 0;
-}
-
-.accordion-item {
-  color: var(--bs-accordion-color);
-  background-color: var(--bs-accordion-bg);
-  border: var(--bs-accordion-border-width) solid var(--bs-accordion-border-color);
-}
-.accordion-item:first-of-type {
-  border-top-left-radius: var(--bs-accordion-border-radius);
-  border-top-right-radius: var(--bs-accordion-border-radius);
-}
-.accordion-item:first-of-type .accordion-button {
-  border-top-left-radius: var(--bs-accordion-inner-border-radius);
-  border-top-right-radius: var(--bs-accordion-inner-border-radius);
-}
-.accordion-item:not(:first-of-type) {
-  border-top: 0;
-}
-.accordion-item:last-of-type {
-  border-bottom-right-radius: var(--bs-accordion-border-radius);
-  border-bottom-left-radius: var(--bs-accordion-border-radius);
-}
-.accordion-item:last-of-type .accordion-button.collapsed {
-  border-bottom-right-radius: var(--bs-accordion-inner-border-radius);
-  border-bottom-left-radius: var(--bs-accordion-inner-border-radius);
-}
-.accordion-item:last-of-type .accordion-collapse {
-  border-bottom-right-radius: var(--bs-accordion-border-radius);
-  border-bottom-left-radius: var(--bs-accordion-border-radius);
-}
-
-.accordion-body {
-  padding: var(--bs-accordion-body-padding-y) var(--bs-accordion-body-padding-x);
-}
-
-.accordion-flush .accordion-collapse {
-  border-width: 0;
-}
-.accordion-flush .accordion-item {
-  border-right: 0;
-  border-left: 0;
-  border-radius: 0;
-}
-.accordion-flush .accordion-item:first-child {
-  border-top: 0;
-}
-.accordion-flush .accordion-item:last-child {
-  border-bottom: 0;
-}
-.accordion-flush .accordion-item .accordion-button, .accordion-flush .accordion-item .accordion-button.collapsed {
-  border-radius: 0;
+    font-size: 0.875rem;
 }
 
 [data-bs-theme=dark] .accordion-button::after {
-  --bs-accordion-btn-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%239792ef'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
-  --bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%239792ef'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
+    --bs-accordion-btn-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%239792ef'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
+    --bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%239792ef'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
 }
 
-.breadcrumb {
-  --bs-breadcrumb-padding-x: 0;
-  --bs-breadcrumb-padding-y: 0;
-  --bs-breadcrumb-margin-bottom: 1rem;
-  --bs-breadcrumb-bg: ;
-  --bs-breadcrumb-border-radius: ;
-  --bs-breadcrumb-divider-color: var(--bs-secondary-color);
-  --bs-breadcrumb-item-padding-x: 0.5rem;
-  --bs-breadcrumb-item-active-color: var(--bs-secondary-color);
-  display: flex;
-  flex-wrap: wrap;
-  padding: var(--bs-breadcrumb-padding-y) var(--bs-breadcrumb-padding-x);
-  margin-bottom: var(--bs-breadcrumb-margin-bottom);
-  font-size: var(--bs-breadcrumb-font-size);
-  list-style: none;
-  background-color: var(--bs-breadcrumb-bg);
-  border-radius: var(--bs-breadcrumb-border-radius);
-}
-
-.breadcrumb-item + .breadcrumb-item {
-  padding-left: var(--bs-breadcrumb-item-padding-x);
-}
-.breadcrumb-item + .breadcrumb-item::before {
-  float: left;
-  padding-right: var(--bs-breadcrumb-item-padding-x);
-  color: var(--bs-breadcrumb-divider-color);
-  content: var(--bs-breadcrumb-divider, "/") /* rtl: var(--bs-breadcrumb-divider, "/") */;
-}
-.breadcrumb-item.active {
-  color: var(--bs-breadcrumb-item-active-color);
-}
 
 .pagination {
-  --bs-pagination-padding-x: 0.75rem;
-  --bs-pagination-padding-y: 0.375rem;
-  --bs-pagination-font-size: 0.875rem;
-  --bs-pagination-color: var(--bs-link-color);
-  --bs-pagination-bg: var(--bs-body-bg);
-  --bs-pagination-border-width: var(--bs-border-width);
-  --bs-pagination-border-color: var(--bs-border-color);
-  --bs-pagination-border-radius: var(--bs-border-radius);
-  --bs-pagination-hover-color: var(--bs-link-hover-color);
-  --bs-pagination-hover-bg: var(--bs-tertiary-bg);
-  --bs-pagination-hover-border-color: var(--bs-border-color);
-  --bs-pagination-focus-color: var(--bs-link-hover-color);
-  --bs-pagination-focus-bg: var(--bs-secondary-bg);
-  --bs-pagination-focus-box-shadow: 0 0 0 0.25rem rgba(81, 73, 229, 0.25);
-  --bs-pagination-active-color: #fff;
-  --bs-pagination-active-bg: #5149e5;
-  --bs-pagination-active-border-color: #5149e5;
-  --bs-pagination-disabled-color: var(--bs-secondary-color);
-  --bs-pagination-disabled-bg: var(--bs-secondary-bg);
-  --bs-pagination-disabled-border-color: var(--bs-border-color);
-  display: flex;
-  padding-left: 0;
-  list-style: none;
+    --bs-pagination-font-size: 0.875rem;
+    --bs-pagination-focus-box-shadow: 0 0 0 0.25rem rgba(81, 73, 229, 0.25);
+    --bs-pagination-active-bg: #5149e5;
+    --bs-pagination-active-border-color: #5149e5;
 }
 
-.page-link {
-  position: relative;
-  display: block;
-  padding: var(--bs-pagination-padding-y) var(--bs-pagination-padding-x);
-  font-size: var(--bs-pagination-font-size);
-  color: var(--bs-pagination-color);
-  text-decoration: none;
-  background-color: var(--bs-pagination-bg);
-  border: var(--bs-pagination-border-width) solid var(--bs-pagination-border-color);
-  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-}
-@media (prefers-reduced-motion: reduce) {
-  .page-link {
-    transition: none;
-  }
-}
-.page-link:hover {
-  z-index: 2;
-  color: var(--bs-pagination-hover-color);
-  background-color: var(--bs-pagination-hover-bg);
-  border-color: var(--bs-pagination-hover-border-color);
-}
-.page-link:focus {
-  z-index: 3;
-  color: var(--bs-pagination-focus-color);
-  background-color: var(--bs-pagination-focus-bg);
-  outline: 0;
-  box-shadow: var(--bs-pagination-focus-box-shadow);
-}
-.page-link.active, .active > .page-link {
-  z-index: 3;
-  color: var(--bs-pagination-active-color);
-  background-color: var(--bs-pagination-active-bg);
-  border-color: var(--bs-pagination-active-border-color);
-}
-.page-link.disabled, .disabled > .page-link {
-  color: var(--bs-pagination-disabled-color);
-  pointer-events: none;
-  background-color: var(--bs-pagination-disabled-bg);
-  border-color: var(--bs-pagination-disabled-border-color);
-}
-
-.page-item:not(:first-child) .page-link {
-  margin-left: calc(var(--bs-border-width) * -1);
-}
-.page-item:first-child .page-link {
-  border-top-left-radius: var(--bs-pagination-border-radius);
-  border-bottom-left-radius: var(--bs-pagination-border-radius);
-}
-.page-item:last-child .page-link {
-  border-top-right-radius: var(--bs-pagination-border-radius);
-  border-bottom-right-radius: var(--bs-pagination-border-radius);
-}
 
 .pagination-lg {
-  --bs-pagination-padding-x: 1.5rem;
-  --bs-pagination-padding-y: 0.75rem;
-  --bs-pagination-font-size: 1.09375rem;
-  --bs-pagination-border-radius: var(--bs-border-radius-lg);
+    --bs-pagination-font-size: 1.09375rem;
 }
 
 .pagination-sm {
-  --bs-pagination-padding-x: 0.5rem;
-  --bs-pagination-padding-y: 0.25rem;
-  --bs-pagination-font-size: 0.765625rem;
-  --bs-pagination-border-radius: var(--bs-border-radius-sm);
+    --bs-pagination-font-size: 0.765625rem;
 }
 
-.badge {
-  --bs-badge-padding-x: 0.65em;
-  --bs-badge-padding-y: 0.35em;
-  --bs-badge-font-size: 0.75em;
-  --bs-badge-font-weight: 700;
-  --bs-badge-color: #fff;
-  --bs-badge-border-radius: var(--bs-border-radius);
-  display: inline-block;
-  padding: var(--bs-badge-padding-y) var(--bs-badge-padding-x);
-  font-size: var(--bs-badge-font-size);
-  font-weight: var(--bs-badge-font-weight);
-  line-height: 1;
-  color: var(--bs-badge-color);
-  text-align: center;
-  white-space: nowrap;
-  vertical-align: baseline;
-  border-radius: var(--bs-badge-border-radius);
-}
-.badge:empty {
-  display: none;
-}
 
-.btn .badge {
-  position: relative;
-  top: -1px;
-}
-
-.alert {
-  --bs-alert-bg: transparent;
-  --bs-alert-padding-x: 1rem;
-  --bs-alert-padding-y: 1rem;
-  --bs-alert-margin-bottom: 1rem;
-  --bs-alert-color: inherit;
-  --bs-alert-border-color: transparent;
-  --bs-alert-border: var(--bs-border-width) solid var(--bs-alert-border-color);
-  --bs-alert-border-radius: var(--bs-border-radius);
-  --bs-alert-link-color: inherit;
-  position: relative;
-  padding: var(--bs-alert-padding-y) var(--bs-alert-padding-x);
-  margin-bottom: var(--bs-alert-margin-bottom);
-  color: var(--bs-alert-color);
-  background-color: var(--bs-alert-bg);
-  border: var(--bs-alert-border);
-  border-radius: var(--bs-alert-border-radius);
-}
-
-.alert-heading {
-  color: inherit;
-}
-
-.alert-link {
-  font-weight: 700;
-  color: var(--bs-alert-link-color);
-}
-
-.alert-dismissible {
-  padding-right: 3rem;
-}
-.alert-dismissible .btn-close {
-  position: absolute;
-  top: 0;
-  right: 0;
-  z-index: 2;
-  padding: 1.25rem 1rem;
-}
-
-.alert-primary {
-  --bs-alert-color: var(--bs-primary-text-emphasis);
-  --bs-alert-bg: var(--bs-primary-bg-subtle);
-  --bs-alert-border-color: var(--bs-primary-border-subtle);
-  --bs-alert-link-color: var(--bs-primary-text-emphasis);
-}
-
-.alert-secondary {
-  --bs-alert-color: var(--bs-secondary-text-emphasis);
-  --bs-alert-bg: var(--bs-secondary-bg-subtle);
-  --bs-alert-border-color: var(--bs-secondary-border-subtle);
-  --bs-alert-link-color: var(--bs-secondary-text-emphasis);
-}
-
-.alert-success {
-  --bs-alert-color: var(--bs-success-text-emphasis);
-  --bs-alert-bg: var(--bs-success-bg-subtle);
-  --bs-alert-border-color: var(--bs-success-border-subtle);
-  --bs-alert-link-color: var(--bs-success-text-emphasis);
-}
-
-.alert-info {
-  --bs-alert-color: var(--bs-info-text-emphasis);
-  --bs-alert-bg: var(--bs-info-bg-subtle);
-  --bs-alert-border-color: var(--bs-info-border-subtle);
-  --bs-alert-link-color: var(--bs-info-text-emphasis);
-}
-
-.alert-warning {
-  --bs-alert-color: var(--bs-warning-text-emphasis);
-  --bs-alert-bg: var(--bs-warning-bg-subtle);
-  --bs-alert-border-color: var(--bs-warning-border-subtle);
-  --bs-alert-link-color: var(--bs-warning-text-emphasis);
-}
-
-.alert-danger {
-  --bs-alert-color: var(--bs-danger-text-emphasis);
-  --bs-alert-bg: var(--bs-danger-bg-subtle);
-  --bs-alert-border-color: var(--bs-danger-border-subtle);
-  --bs-alert-link-color: var(--bs-danger-text-emphasis);
-}
-
-.alert-light {
-  --bs-alert-color: var(--bs-light-text-emphasis);
-  --bs-alert-bg: var(--bs-light-bg-subtle);
-  --bs-alert-border-color: var(--bs-light-border-subtle);
-  --bs-alert-link-color: var(--bs-light-text-emphasis);
-}
-
-.alert-dark {
-  --bs-alert-color: var(--bs-dark-text-emphasis);
-  --bs-alert-bg: var(--bs-dark-bg-subtle);
-  --bs-alert-border-color: var(--bs-dark-border-subtle);
-  --bs-alert-link-color: var(--bs-dark-text-emphasis);
-}
-
-@keyframes progress-bar-stripes {
-  0% {
-    background-position-x: 1rem;
-  }
-}
 .progress,
 .progress-stacked {
-  --bs-progress-height: 1rem;
-  --bs-progress-font-size: 0.65625rem;
-  --bs-progress-bg: var(--bs-secondary-bg);
-  --bs-progress-border-radius: var(--bs-border-radius);
-  --bs-progress-box-shadow: var(--bs-box-shadow-inset);
-  --bs-progress-bar-color: #fff;
-  --bs-progress-bar-bg: #5149e5;
-  --bs-progress-bar-transition: width 0.6s ease;
-  display: flex;
-  height: var(--bs-progress-height);
-  overflow: hidden;
-  font-size: var(--bs-progress-font-size);
-  background-color: var(--bs-progress-bg);
-  border-radius: var(--bs-progress-border-radius);
+    --bs-progress-font-size: 0.65625rem;
+    --bs-progress-bar-bg: #5149e5;
+    font-size: var(--bs-progress-font-size);
+    background-color: var(--bs-progress-bg);
 }
 
-.progress-bar {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  overflow: hidden;
-  color: var(--bs-progress-bar-color);
-  text-align: center;
-  white-space: nowrap;
-  background-color: var(--bs-progress-bar-bg);
-  transition: var(--bs-progress-bar-transition);
-}
-@media (prefers-reduced-motion: reduce) {
-  .progress-bar {
-    transition: none;
-  }
-}
-
-.progress-bar-striped {
-  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-  background-size: var(--bs-progress-height) var(--bs-progress-height);
-}
-
-.progress-stacked > .progress {
-  overflow: visible;
-}
-
-.progress-stacked > .progress > .progress-bar {
-  width: 100%;
-}
-
-.progress-bar-animated {
-  animation: 1s linear infinite progress-bar-stripes;
-}
-@media (prefers-reduced-motion: reduce) {
-  .progress-bar-animated {
-    animation: none;
-  }
-}
 
 .list-group {
-  --bs-list-group-color: var(--bs-body-color);
-  --bs-list-group-bg: var(--bs-body-bg);
-  --bs-list-group-border-color: var(--bs-border-color);
-  --bs-list-group-border-width: var(--bs-border-width);
-  --bs-list-group-border-radius: var(--bs-border-radius);
-  --bs-list-group-item-padding-x: 1.5rem;
-  --bs-list-group-item-padding-y: 0.75rem;
-  --bs-list-group-action-color: var(--bs-secondary-color);
-  --bs-list-group-action-hover-color: var(--bs-emphasis-color);
-  --bs-list-group-action-hover-bg: var(--bs-tertiary-bg);
-  --bs-list-group-action-active-color: var(--bs-body-color);
-  --bs-list-group-action-active-bg: var(--bs-secondary-bg);
-  --bs-list-group-disabled-color: var(--bs-secondary-color);
-  --bs-list-group-disabled-bg: var(--bs-body-bg);
-  --bs-list-group-active-color: #fff;
-  --bs-list-group-active-bg: #5149e5;
-  --bs-list-group-active-border-color: #5149e5;
-  display: flex;
-  flex-direction: column;
-  padding-left: 0;
-  margin-bottom: 0;
-  border-radius: var(--bs-list-group-border-radius);
+    --bs-list-group-item-padding-x: 1.5rem;
+    --bs-list-group-item-padding-y: 0.75rem;
+    --bs-list-group-active-bg: #5149e5;
+    --bs-list-group-active-border-color: #5149e5;
 }
 
-.list-group-numbered {
-  list-style-type: none;
-  counter-reset: section;
-}
-.list-group-numbered > .list-group-item::before {
-  content: counters(section, ".") ". ";
-  counter-increment: section;
-}
-
-.list-group-item-action {
-  width: 100%;
-  color: var(--bs-list-group-action-color);
-  text-align: inherit;
-}
-.list-group-item-action:hover, .list-group-item-action:focus {
-  z-index: 1;
-  color: var(--bs-list-group-action-hover-color);
-  text-decoration: none;
-  background-color: var(--bs-list-group-action-hover-bg);
-}
-.list-group-item-action:active {
-  color: var(--bs-list-group-action-active-color);
-  background-color: var(--bs-list-group-action-active-bg);
-}
-
-.list-group-item {
-  position: relative;
-  display: block;
-  padding: var(--bs-list-group-item-padding-y) var(--bs-list-group-item-padding-x);
-  color: var(--bs-list-group-color);
-  text-decoration: none;
-  background-color: var(--bs-list-group-bg);
-  border: var(--bs-list-group-border-width) solid var(--bs-list-group-border-color);
-}
-.list-group-item:first-child {
-  border-top-left-radius: inherit;
-  border-top-right-radius: inherit;
-}
-.list-group-item:last-child {
-  border-bottom-right-radius: inherit;
-  border-bottom-left-radius: inherit;
-}
-.list-group-item.disabled, .list-group-item:disabled {
-  color: var(--bs-list-group-disabled-color);
-  pointer-events: none;
-  background-color: var(--bs-list-group-disabled-bg);
-}
-.list-group-item.active {
-  z-index: 2;
-  color: var(--bs-list-group-active-color);
-  background-color: var(--bs-list-group-active-bg);
-  border-color: var(--bs-list-group-active-border-color);
-}
-.list-group-item + .list-group-item {
-  border-top-width: 0;
-}
-.list-group-item + .list-group-item.active {
-  margin-top: calc(-1 * var(--bs-list-group-border-width));
-  border-top-width: var(--bs-list-group-border-width);
-}
-
-.list-group-horizontal {
-  flex-direction: row;
-}
-.list-group-horizontal > .list-group-item:first-child:not(:last-child) {
-  border-bottom-left-radius: var(--bs-list-group-border-radius);
-  border-top-right-radius: 0;
-}
-.list-group-horizontal > .list-group-item:last-child:not(:first-child) {
-  border-top-right-radius: var(--bs-list-group-border-radius);
-  border-bottom-left-radius: 0;
-}
-.list-group-horizontal > .list-group-item.active {
-  margin-top: 0;
-}
-.list-group-horizontal > .list-group-item + .list-group-item {
-  border-top-width: var(--bs-list-group-border-width);
-  border-left-width: 0;
-}
-.list-group-horizontal > .list-group-item + .list-group-item.active {
-  margin-left: calc(-1 * var(--bs-list-group-border-width));
-  border-left-width: var(--bs-list-group-border-width);
-}
-
-@media (min-width: 576px) {
-  .list-group-horizontal-sm {
-    flex-direction: row;
-  }
-  .list-group-horizontal-sm > .list-group-item:first-child:not(:last-child) {
-    border-bottom-left-radius: var(--bs-list-group-border-radius);
-    border-top-right-radius: 0;
-  }
-  .list-group-horizontal-sm > .list-group-item:last-child:not(:first-child) {
-    border-top-right-radius: var(--bs-list-group-border-radius);
-    border-bottom-left-radius: 0;
-  }
-  .list-group-horizontal-sm > .list-group-item.active {
-    margin-top: 0;
-  }
-  .list-group-horizontal-sm > .list-group-item + .list-group-item {
-    border-top-width: var(--bs-list-group-border-width);
-    border-left-width: 0;
-  }
-  .list-group-horizontal-sm > .list-group-item + .list-group-item.active {
-    margin-left: calc(-1 * var(--bs-list-group-border-width));
-    border-left-width: var(--bs-list-group-border-width);
-  }
-}
-@media (min-width: 768px) {
-  .list-group-horizontal-md {
-    flex-direction: row;
-  }
-  .list-group-horizontal-md > .list-group-item:first-child:not(:last-child) {
-    border-bottom-left-radius: var(--bs-list-group-border-radius);
-    border-top-right-radius: 0;
-  }
-  .list-group-horizontal-md > .list-group-item:last-child:not(:first-child) {
-    border-top-right-radius: var(--bs-list-group-border-radius);
-    border-bottom-left-radius: 0;
-  }
-  .list-group-horizontal-md > .list-group-item.active {
-    margin-top: 0;
-  }
-  .list-group-horizontal-md > .list-group-item + .list-group-item {
-    border-top-width: var(--bs-list-group-border-width);
-    border-left-width: 0;
-  }
-  .list-group-horizontal-md > .list-group-item + .list-group-item.active {
-    margin-left: calc(-1 * var(--bs-list-group-border-width));
-    border-left-width: var(--bs-list-group-border-width);
-  }
-}
-@media (min-width: 992px) {
-  .list-group-horizontal-lg {
-    flex-direction: row;
-  }
-  .list-group-horizontal-lg > .list-group-item:first-child:not(:last-child) {
-    border-bottom-left-radius: var(--bs-list-group-border-radius);
-    border-top-right-radius: 0;
-  }
-  .list-group-horizontal-lg > .list-group-item:last-child:not(:first-child) {
-    border-top-right-radius: var(--bs-list-group-border-radius);
-    border-bottom-left-radius: 0;
-  }
-  .list-group-horizontal-lg > .list-group-item.active {
-    margin-top: 0;
-  }
-  .list-group-horizontal-lg > .list-group-item + .list-group-item {
-    border-top-width: var(--bs-list-group-border-width);
-    border-left-width: 0;
-  }
-  .list-group-horizontal-lg > .list-group-item + .list-group-item.active {
-    margin-left: calc(-1 * var(--bs-list-group-border-width));
-    border-left-width: var(--bs-list-group-border-width);
-  }
-}
-@media (min-width: 1200px) {
-  .list-group-horizontal-xl {
-    flex-direction: row;
-  }
-  .list-group-horizontal-xl > .list-group-item:first-child:not(:last-child) {
-    border-bottom-left-radius: var(--bs-list-group-border-radius);
-    border-top-right-radius: 0;
-  }
-  .list-group-horizontal-xl > .list-group-item:last-child:not(:first-child) {
-    border-top-right-radius: var(--bs-list-group-border-radius);
-    border-bottom-left-radius: 0;
-  }
-  .list-group-horizontal-xl > .list-group-item.active {
-    margin-top: 0;
-  }
-  .list-group-horizontal-xl > .list-group-item + .list-group-item {
-    border-top-width: var(--bs-list-group-border-width);
-    border-left-width: 0;
-  }
-  .list-group-horizontal-xl > .list-group-item + .list-group-item.active {
-    margin-left: calc(-1 * var(--bs-list-group-border-width));
-    border-left-width: var(--bs-list-group-border-width);
-  }
-}
-@media (min-width: 1400px) {
-  .list-group-horizontal-xxl {
-    flex-direction: row;
-  }
-  .list-group-horizontal-xxl > .list-group-item:first-child:not(:last-child) {
-    border-bottom-left-radius: var(--bs-list-group-border-radius);
-    border-top-right-radius: 0;
-  }
-  .list-group-horizontal-xxl > .list-group-item:last-child:not(:first-child) {
-    border-top-right-radius: var(--bs-list-group-border-radius);
-    border-bottom-left-radius: 0;
-  }
-  .list-group-horizontal-xxl > .list-group-item.active {
-    margin-top: 0;
-  }
-  .list-group-horizontal-xxl > .list-group-item + .list-group-item {
-    border-top-width: var(--bs-list-group-border-width);
-    border-left-width: 0;
-  }
-  .list-group-horizontal-xxl > .list-group-item + .list-group-item.active {
-    margin-left: calc(-1 * var(--bs-list-group-border-width));
-    border-left-width: var(--bs-list-group-border-width);
-  }
-}
-.list-group-flush {
-  border-radius: 0;
-}
-.list-group-flush > .list-group-item {
-  border-width: 0 0 var(--bs-list-group-border-width);
-}
-.list-group-flush > .list-group-item:last-child {
-  border-bottom-width: 0;
-}
-
-.list-group-item-primary {
-  --bs-list-group-color: var(--bs-primary-text-emphasis);
-  --bs-list-group-bg: var(--bs-primary-bg-subtle);
-  --bs-list-group-border-color: var(--bs-primary-border-subtle);
-  --bs-list-group-action-hover-color: var(--bs-emphasis-color);
-  --bs-list-group-action-hover-bg: var(--bs-primary-border-subtle);
-  --bs-list-group-action-active-color: var(--bs-emphasis-color);
-  --bs-list-group-action-active-bg: var(--bs-primary-border-subtle);
-  --bs-list-group-active-color: var(--bs-primary-bg-subtle);
-  --bs-list-group-active-bg: var(--bs-primary-text-emphasis);
-  --bs-list-group-active-border-color: var(--bs-primary-text-emphasis);
-}
-
-.list-group-item-secondary {
-  --bs-list-group-color: var(--bs-secondary-text-emphasis);
-  --bs-list-group-bg: var(--bs-secondary-bg-subtle);
-  --bs-list-group-border-color: var(--bs-secondary-border-subtle);
-  --bs-list-group-action-hover-color: var(--bs-emphasis-color);
-  --bs-list-group-action-hover-bg: var(--bs-secondary-border-subtle);
-  --bs-list-group-action-active-color: var(--bs-emphasis-color);
-  --bs-list-group-action-active-bg: var(--bs-secondary-border-subtle);
-  --bs-list-group-active-color: var(--bs-secondary-bg-subtle);
-  --bs-list-group-active-bg: var(--bs-secondary-text-emphasis);
-  --bs-list-group-active-border-color: var(--bs-secondary-text-emphasis);
-}
-
-.list-group-item-success {
-  --bs-list-group-color: var(--bs-success-text-emphasis);
-  --bs-list-group-bg: var(--bs-success-bg-subtle);
-  --bs-list-group-border-color: var(--bs-success-border-subtle);
-  --bs-list-group-action-hover-color: var(--bs-emphasis-color);
-  --bs-list-group-action-hover-bg: var(--bs-success-border-subtle);
-  --bs-list-group-action-active-color: var(--bs-emphasis-color);
-  --bs-list-group-action-active-bg: var(--bs-success-border-subtle);
-  --bs-list-group-active-color: var(--bs-success-bg-subtle);
-  --bs-list-group-active-bg: var(--bs-success-text-emphasis);
-  --bs-list-group-active-border-color: var(--bs-success-text-emphasis);
-}
-
-.list-group-item-info {
-  --bs-list-group-color: var(--bs-info-text-emphasis);
-  --bs-list-group-bg: var(--bs-info-bg-subtle);
-  --bs-list-group-border-color: var(--bs-info-border-subtle);
-  --bs-list-group-action-hover-color: var(--bs-emphasis-color);
-  --bs-list-group-action-hover-bg: var(--bs-info-border-subtle);
-  --bs-list-group-action-active-color: var(--bs-emphasis-color);
-  --bs-list-group-action-active-bg: var(--bs-info-border-subtle);
-  --bs-list-group-active-color: var(--bs-info-bg-subtle);
-  --bs-list-group-active-bg: var(--bs-info-text-emphasis);
-  --bs-list-group-active-border-color: var(--bs-info-text-emphasis);
-}
-
-.list-group-item-warning {
-  --bs-list-group-color: var(--bs-warning-text-emphasis);
-  --bs-list-group-bg: var(--bs-warning-bg-subtle);
-  --bs-list-group-border-color: var(--bs-warning-border-subtle);
-  --bs-list-group-action-hover-color: var(--bs-emphasis-color);
-  --bs-list-group-action-hover-bg: var(--bs-warning-border-subtle);
-  --bs-list-group-action-active-color: var(--bs-emphasis-color);
-  --bs-list-group-action-active-bg: var(--bs-warning-border-subtle);
-  --bs-list-group-active-color: var(--bs-warning-bg-subtle);
-  --bs-list-group-active-bg: var(--bs-warning-text-emphasis);
-  --bs-list-group-active-border-color: var(--bs-warning-text-emphasis);
-}
-
-.list-group-item-danger {
-  --bs-list-group-color: var(--bs-danger-text-emphasis);
-  --bs-list-group-bg: var(--bs-danger-bg-subtle);
-  --bs-list-group-border-color: var(--bs-danger-border-subtle);
-  --bs-list-group-action-hover-color: var(--bs-emphasis-color);
-  --bs-list-group-action-hover-bg: var(--bs-danger-border-subtle);
-  --bs-list-group-action-active-color: var(--bs-emphasis-color);
-  --bs-list-group-action-active-bg: var(--bs-danger-border-subtle);
-  --bs-list-group-active-color: var(--bs-danger-bg-subtle);
-  --bs-list-group-active-bg: var(--bs-danger-text-emphasis);
-  --bs-list-group-active-border-color: var(--bs-danger-text-emphasis);
-}
-
-.list-group-item-light {
-  --bs-list-group-color: var(--bs-light-text-emphasis);
-  --bs-list-group-bg: var(--bs-light-bg-subtle);
-  --bs-list-group-border-color: var(--bs-light-border-subtle);
-  --bs-list-group-action-hover-color: var(--bs-emphasis-color);
-  --bs-list-group-action-hover-bg: var(--bs-light-border-subtle);
-  --bs-list-group-action-active-color: var(--bs-emphasis-color);
-  --bs-list-group-action-active-bg: var(--bs-light-border-subtle);
-  --bs-list-group-active-color: var(--bs-light-bg-subtle);
-  --bs-list-group-active-bg: var(--bs-light-text-emphasis);
-  --bs-list-group-active-border-color: var(--bs-light-text-emphasis);
-}
-
-.list-group-item-dark {
-  --bs-list-group-color: var(--bs-dark-text-emphasis);
-  --bs-list-group-bg: var(--bs-dark-bg-subtle);
-  --bs-list-group-border-color: var(--bs-dark-border-subtle);
-  --bs-list-group-action-hover-color: var(--bs-emphasis-color);
-  --bs-list-group-action-hover-bg: var(--bs-dark-border-subtle);
-  --bs-list-group-action-active-color: var(--bs-emphasis-color);
-  --bs-list-group-action-active-bg: var(--bs-dark-border-subtle);
-  --bs-list-group-active-color: var(--bs-dark-bg-subtle);
-  --bs-list-group-active-bg: var(--bs-dark-text-emphasis);
-  --bs-list-group-active-border-color: var(--bs-dark-text-emphasis);
-}
 
 .btn-close {
-  --bs-btn-close-color: #000;
-  --bs-btn-close-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23000'%3e%3cpath d='M.293.293a1 1 0 0 1 1.414 0L8 6.586 14.293.293a1 1 0 1 1 1.414 1.414L9.414 8l6.293 6.293a1 1 0 0 1-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 0 1-1.414-1.414L6.586 8 .293 1.707a1 1 0 0 1 0-1.414z'/%3e%3c/svg%3e");
-  --bs-btn-close-opacity: 0.5;
-  --bs-btn-close-hover-opacity: 0.75;
-  --bs-btn-close-focus-shadow: 0 0 0 0.25rem rgba(81, 73, 229, 0.25);
-  --bs-btn-close-focus-opacity: 1;
-  --bs-btn-close-disabled-opacity: 0.25;
-  --bs-btn-close-white-filter: invert(1) grayscale(100%) brightness(200%);
-  box-sizing: content-box;
-  width: 1em;
-  height: 1em;
-  padding: 0.25em 0.25em;
-  color: var(--bs-btn-close-color);
-  background: transparent var(--bs-btn-close-bg) center/1em auto no-repeat;
-  border: 0;
-  border-radius: 0.5rem;
-  opacity: var(--bs-btn-close-opacity);
-}
-.btn-close:hover {
-  color: var(--bs-btn-close-color);
-  text-decoration: none;
-  opacity: var(--bs-btn-close-hover-opacity);
-}
-.btn-close:focus {
-  outline: 0;
-  box-shadow: var(--bs-btn-close-focus-shadow);
-  opacity: var(--bs-btn-close-focus-opacity);
-}
-.btn-close:disabled, .btn-close.disabled {
-  pointer-events: none;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-          user-select: none;
-  opacity: var(--bs-btn-close-disabled-opacity);
-}
-
-.btn-close-white {
-  filter: var(--bs-btn-close-white-filter);
-}
-
-[data-bs-theme=dark] .btn-close {
-  filter: var(--bs-btn-close-white-filter);
-}
-
-.toast {
-  --bs-toast-zindex: 1090;
-  --bs-toast-padding-x: 0.75rem;
-  --bs-toast-padding-y: 0.5rem;
-  --bs-toast-spacing: 1.5rem;
-  --bs-toast-max-width: 350px;
-  --bs-toast-font-size: 0.875rem;
-  --bs-toast-color: ;
-  --bs-toast-bg: rgba(var(--bs-body-bg-rgb), 0.85);
-  --bs-toast-border-width: var(--bs-border-width);
-  --bs-toast-border-color: var(--bs-border-color-translucent);
-  --bs-toast-border-radius: var(--bs-border-radius);
-  --bs-toast-box-shadow: var(--bs-box-shadow);
-  --bs-toast-header-color: var(--bs-secondary-color);
-  --bs-toast-header-bg: rgba(var(--bs-body-bg-rgb), 0.85);
-  --bs-toast-header-border-color: var(--bs-border-color-translucent);
-  width: var(--bs-toast-max-width);
-  max-width: 100%;
-  font-size: var(--bs-toast-font-size);
-  color: var(--bs-toast-color);
-  pointer-events: auto;
-  background-color: var(--bs-toast-bg);
-  background-clip: padding-box;
-  border: var(--bs-toast-border-width) solid var(--bs-toast-border-color);
-  box-shadow: var(--bs-toast-box-shadow);
-  border-radius: var(--bs-toast-border-radius);
-}
-.toast.showing {
-  opacity: 0;
-}
-.toast:not(.show) {
-  display: none;
+    --bs-btn-close-focus-shadow: 0 0 0 0.25rem rgba(81, 73, 229, 0.25);
+    border-radius: 0.5rem;
 }
 
 .toast-container {
-  --bs-toast-zindex: 1090;
-  position: absolute;
-  z-index: var(--bs-toast-zindex);
-  width: -moz-max-content;
-  width: max-content;
-  max-width: 100%;
-  pointer-events: none;
-}
-.toast-container > :not(:last-child) {
-  margin-bottom: var(--bs-toast-spacing);
+    width: initial;
+    width: -moz-max-content;
+    width: max-content;
 }
 
-.toast-header {
-  display: flex;
-  align-items: center;
-  padding: var(--bs-toast-padding-y) var(--bs-toast-padding-x);
-  color: var(--bs-toast-header-color);
-  background-color: var(--bs-toast-header-bg);
-  background-clip: padding-box;
-  border-bottom: var(--bs-toast-border-width) solid var(--bs-toast-header-border-color);
-  border-top-left-radius: calc(var(--bs-toast-border-radius) - var(--bs-toast-border-width));
-  border-top-right-radius: calc(var(--bs-toast-border-radius) - var(--bs-toast-border-width));
-}
-.toast-header .btn-close {
-  margin-right: calc(-0.5 * var(--bs-toast-padding-x));
-  margin-left: var(--bs-toast-padding-x);
-}
-
-.toast-body {
-  padding: var(--bs-toast-padding-x);
-  word-wrap: break-word;
-}
-
-.modal {
-  --bs-modal-zindex: 1055;
-  --bs-modal-width: 500px;
-  --bs-modal-padding: 1rem;
-  --bs-modal-margin: 0.5rem;
-  --bs-modal-color: ;
-  --bs-modal-bg: var(--bs-body-bg);
-  --bs-modal-border-color: var(--bs-border-color-translucent);
-  --bs-modal-border-width: var(--bs-border-width);
-  --bs-modal-border-radius: var(--bs-border-radius-lg);
-  --bs-modal-box-shadow: var(--bs-box-shadow-sm);
-  --bs-modal-inner-border-radius: calc(var(--bs-border-radius-lg) - (var(--bs-border-width)));
-  --bs-modal-header-padding-x: 1rem;
-  --bs-modal-header-padding-y: 1rem;
-  --bs-modal-header-padding: 1rem 1rem;
-  --bs-modal-header-border-color: var(--bs-border-color);
-  --bs-modal-header-border-width: var(--bs-border-width);
-  --bs-modal-title-line-height: 1.5;
-  --bs-modal-footer-gap: 0.5rem;
-  --bs-modal-footer-bg: ;
-  --bs-modal-footer-border-color: var(--bs-border-color);
-  --bs-modal-footer-border-width: var(--bs-border-width);
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: var(--bs-modal-zindex);
-  display: none;
-  width: 100%;
-  height: 100%;
-  overflow-x: hidden;
-  overflow-y: auto;
-  outline: 0;
-}
-
-.modal-dialog {
-  position: relative;
-  width: auto;
-  margin: var(--bs-modal-margin);
-  pointer-events: none;
-}
-.modal.fade .modal-dialog {
-  transition: transform 0.3s ease-out;
-  transform: translate(0, -50px);
-}
-@media (prefers-reduced-motion: reduce) {
-  .modal.fade .modal-dialog {
-    transition: none;
-  }
-}
-.modal.show .modal-dialog {
-  transform: none;
-}
-.modal.modal-static .modal-dialog {
-  transform: scale(1.02);
-}
-
-.modal-dialog-scrollable {
-  height: calc(100% - var(--bs-modal-margin) * 2);
-}
-.modal-dialog-scrollable .modal-content {
-  max-height: 100%;
-  overflow: hidden;
-}
-.modal-dialog-scrollable .modal-body {
-  overflow-y: auto;
-}
-
-.modal-dialog-centered {
-  display: flex;
-  align-items: center;
-  min-height: calc(100% - var(--bs-modal-margin) * 2);
-}
-
-.modal-content {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  color: var(--bs-modal-color);
-  pointer-events: auto;
-  background-color: var(--bs-modal-bg);
-  background-clip: padding-box;
-  border: var(--bs-modal-border-width) solid var(--bs-modal-border-color);
-  border-radius: var(--bs-modal-border-radius);
-  outline: 0;
-}
-
-.modal-backdrop {
-  --bs-backdrop-zindex: 1050;
-  --bs-backdrop-bg: #000;
-  --bs-backdrop-opacity: 0.5;
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: var(--bs-backdrop-zindex);
-  width: 100vw;
-  height: 100vh;
-  background-color: var(--bs-backdrop-bg);
-}
-.modal-backdrop.fade {
-  opacity: 0;
-}
-.modal-backdrop.show {
-  opacity: var(--bs-backdrop-opacity);
-}
-
-.modal-header {
-  display: flex;
-  flex-shrink: 0;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--bs-modal-header-padding);
-  border-bottom: var(--bs-modal-header-border-width) solid var(--bs-modal-header-border-color);
-  border-top-left-radius: var(--bs-modal-inner-border-radius);
-  border-top-right-radius: var(--bs-modal-inner-border-radius);
-}
-.modal-header .btn-close {
-  padding: calc(var(--bs-modal-header-padding-y) * 0.5) calc(var(--bs-modal-header-padding-x) * 0.5);
-  margin: calc(-0.5 * var(--bs-modal-header-padding-y)) calc(-0.5 * var(--bs-modal-header-padding-x)) calc(-0.5 * var(--bs-modal-header-padding-y)) auto;
-}
-
-.modal-title {
-  margin-bottom: 0;
-  line-height: var(--bs-modal-title-line-height);
-}
-
-.modal-body {
-  position: relative;
-  flex: 1 1 auto;
-  padding: var(--bs-modal-padding);
-}
-
-.modal-footer {
-  display: flex;
-  flex-shrink: 0;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: flex-end;
-  padding: calc(var(--bs-modal-padding) - var(--bs-modal-footer-gap) * 0.5);
-  background-color: var(--bs-modal-footer-bg);
-  border-top: var(--bs-modal-footer-border-width) solid var(--bs-modal-footer-border-color);
-  border-bottom-right-radius: var(--bs-modal-inner-border-radius);
-  border-bottom-left-radius: var(--bs-modal-inner-border-radius);
-}
-.modal-footer > * {
-  margin: calc(var(--bs-modal-footer-gap) * 0.5);
-}
-
-@media (min-width: 576px) {
-  .modal {
-    --bs-modal-margin: 1.75rem;
-    --bs-modal-box-shadow: var(--bs-box-shadow);
-  }
-  .modal-dialog {
-    max-width: var(--bs-modal-width);
-    margin-right: auto;
-    margin-left: auto;
-  }
-  .modal-sm {
-    --bs-modal-width: 300px;
-  }
-}
-@media (min-width: 992px) {
-  .modal-lg,
-  .modal-xl {
-    --bs-modal-width: 800px;
-  }
-}
-@media (min-width: 1200px) {
-  .modal-xl {
-    --bs-modal-width: 1140px;
-  }
-}
-.modal-fullscreen {
-  width: 100vw;
-  max-width: none;
-  height: 100%;
-  margin: 0;
-}
-.modal-fullscreen .modal-content {
-  height: 100%;
-  border: 0;
-  border-radius: 0;
-}
-.modal-fullscreen .modal-header,
-.modal-fullscreen .modal-footer {
-  border-radius: 0;
-}
-.modal-fullscreen .modal-body {
-  overflow-y: auto;
-}
-
-@media (max-width: 575.98px) {
-  .modal-fullscreen-sm-down {
-    width: 100vw;
-    max-width: none;
-    height: 100%;
-    margin: 0;
-  }
-  .modal-fullscreen-sm-down .modal-content {
-    height: 100%;
-    border: 0;
-    border-radius: 0;
-  }
-  .modal-fullscreen-sm-down .modal-header,
-  .modal-fullscreen-sm-down .modal-footer {
-    border-radius: 0;
-  }
-  .modal-fullscreen-sm-down .modal-body {
-    overflow-y: auto;
-  }
-}
-@media (max-width: 767.98px) {
-  .modal-fullscreen-md-down {
-    width: 100vw;
-    max-width: none;
-    height: 100%;
-    margin: 0;
-  }
-  .modal-fullscreen-md-down .modal-content {
-    height: 100%;
-    border: 0;
-    border-radius: 0;
-  }
-  .modal-fullscreen-md-down .modal-header,
-  .modal-fullscreen-md-down .modal-footer {
-    border-radius: 0;
-  }
-  .modal-fullscreen-md-down .modal-body {
-    overflow-y: auto;
-  }
-}
-@media (max-width: 991.98px) {
-  .modal-fullscreen-lg-down {
-    width: 100vw;
-    max-width: none;
-    height: 100%;
-    margin: 0;
-  }
-  .modal-fullscreen-lg-down .modal-content {
-    height: 100%;
-    border: 0;
-    border-radius: 0;
-  }
-  .modal-fullscreen-lg-down .modal-header,
-  .modal-fullscreen-lg-down .modal-footer {
-    border-radius: 0;
-  }
-  .modal-fullscreen-lg-down .modal-body {
-    overflow-y: auto;
-  }
-}
-@media (max-width: 1199.98px) {
-  .modal-fullscreen-xl-down {
-    width: 100vw;
-    max-width: none;
-    height: 100%;
-    margin: 0;
-  }
-  .modal-fullscreen-xl-down .modal-content {
-    height: 100%;
-    border: 0;
-    border-radius: 0;
-  }
-  .modal-fullscreen-xl-down .modal-header,
-  .modal-fullscreen-xl-down .modal-footer {
-    border-radius: 0;
-  }
-  .modal-fullscreen-xl-down .modal-body {
-    overflow-y: auto;
-  }
-}
-@media (max-width: 1399.98px) {
-  .modal-fullscreen-xxl-down {
-    width: 100vw;
-    max-width: none;
-    height: 100%;
-    margin: 0;
-  }
-  .modal-fullscreen-xxl-down .modal-content {
-    height: 100%;
-    border: 0;
-    border-radius: 0;
-  }
-  .modal-fullscreen-xxl-down .modal-header,
-  .modal-fullscreen-xxl-down .modal-footer {
-    border-radius: 0;
-  }
-  .modal-fullscreen-xxl-down .modal-body {
-    overflow-y: auto;
-  }
-}
 .tooltip {
-  --bs-tooltip-zindex: 1080;
-  --bs-tooltip-max-width: 200px;
-  --bs-tooltip-padding-x: 0.5rem;
-  --bs-tooltip-padding-y: 0.25rem;
-  --bs-tooltip-margin: ;
-  --bs-tooltip-font-size: 0.765625rem;
-  --bs-tooltip-color: var(--bs-body-bg);
-  --bs-tooltip-bg: var(--bs-emphasis-color);
-  --bs-tooltip-border-radius: var(--bs-border-radius);
-  --bs-tooltip-opacity: 0.9;
-  --bs-tooltip-arrow-width: 0.8rem;
-  --bs-tooltip-arrow-height: 0.4rem;
-  z-index: var(--bs-tooltip-zindex);
-  display: block;
-  margin: var(--bs-tooltip-margin);
-  font-family: var(--bs-font-sans-serif);
-  font-style: normal;
-  font-weight: 400;
-  line-height: 1.5;
-  text-align: left;
-  text-align: start;
-  text-decoration: none;
-  text-shadow: none;
-  text-transform: none;
-  letter-spacing: normal;
-  word-break: normal;
-  white-space: normal;
-  word-spacing: normal;
-  line-break: auto;
-  font-size: var(--bs-tooltip-font-size);
-  word-wrap: break-word;
-  opacity: 0;
-}
-.tooltip.show {
-  opacity: var(--bs-tooltip-opacity);
-}
-.tooltip .tooltip-arrow {
-  display: block;
-  width: var(--bs-tooltip-arrow-width);
-  height: var(--bs-tooltip-arrow-height);
-}
-.tooltip .tooltip-arrow::before {
-  position: absolute;
-  content: "";
-  border-color: transparent;
-  border-style: solid;
+    --bs-tooltip-font-size: 0.765625rem;
+    font-size: var(--bs-tooltip-font-size);
 }
 
-.bs-tooltip-top .tooltip-arrow, .bs-tooltip-auto[data-popper-placement^=top] .tooltip-arrow {
-  bottom: calc(-1 * var(--bs-tooltip-arrow-height));
-}
-.bs-tooltip-top .tooltip-arrow::before, .bs-tooltip-auto[data-popper-placement^=top] .tooltip-arrow::before {
-  top: -1px;
-  border-width: var(--bs-tooltip-arrow-height) calc(var(--bs-tooltip-arrow-width) * 0.5) 0;
-  border-top-color: var(--bs-tooltip-bg);
-}
-
-/* rtl:begin:ignore */
-.bs-tooltip-end .tooltip-arrow, .bs-tooltip-auto[data-popper-placement^=right] .tooltip-arrow {
-  left: calc(-1 * var(--bs-tooltip-arrow-height));
-  width: var(--bs-tooltip-arrow-height);
-  height: var(--bs-tooltip-arrow-width);
-}
-.bs-tooltip-end .tooltip-arrow::before, .bs-tooltip-auto[data-popper-placement^=right] .tooltip-arrow::before {
-  right: -1px;
-  border-width: calc(var(--bs-tooltip-arrow-width) * 0.5) var(--bs-tooltip-arrow-height) calc(var(--bs-tooltip-arrow-width) * 0.5) 0;
-  border-right-color: var(--bs-tooltip-bg);
-}
-
-/* rtl:end:ignore */
-.bs-tooltip-bottom .tooltip-arrow, .bs-tooltip-auto[data-popper-placement^=bottom] .tooltip-arrow {
-  top: calc(-1 * var(--bs-tooltip-arrow-height));
-}
-.bs-tooltip-bottom .tooltip-arrow::before, .bs-tooltip-auto[data-popper-placement^=bottom] .tooltip-arrow::before {
-  bottom: -1px;
-  border-width: 0 calc(var(--bs-tooltip-arrow-width) * 0.5) var(--bs-tooltip-arrow-height);
-  border-bottom-color: var(--bs-tooltip-bg);
-}
-
-/* rtl:begin:ignore */
-.bs-tooltip-start .tooltip-arrow, .bs-tooltip-auto[data-popper-placement^=left] .tooltip-arrow {
-  right: calc(-1 * var(--bs-tooltip-arrow-height));
-  width: var(--bs-tooltip-arrow-height);
-  height: var(--bs-tooltip-arrow-width);
-}
-.bs-tooltip-start .tooltip-arrow::before, .bs-tooltip-auto[data-popper-placement^=left] .tooltip-arrow::before {
-  left: -1px;
-  border-width: calc(var(--bs-tooltip-arrow-width) * 0.5) 0 calc(var(--bs-tooltip-arrow-width) * 0.5) var(--bs-tooltip-arrow-height);
-  border-left-color: var(--bs-tooltip-bg);
-}
-
-/* rtl:end:ignore */
-.tooltip-inner {
-  max-width: var(--bs-tooltip-max-width);
-  padding: var(--bs-tooltip-padding-y) var(--bs-tooltip-padding-x);
-  color: var(--bs-tooltip-color);
-  text-align: center;
-  background-color: var(--bs-tooltip-bg);
-  border-radius: var(--bs-tooltip-border-radius);
-}
 
 .popover {
-  --bs-popover-zindex: 1070;
-  --bs-popover-max-width: 276px;
-  --bs-popover-font-size: 0.765625rem;
-  --bs-popover-bg: var(--bs-body-bg);
-  --bs-popover-border-width: var(--bs-border-width);
-  --bs-popover-border-color: var(--bs-border-color-translucent);
-  --bs-popover-border-radius: var(--bs-border-radius-lg);
-  --bs-popover-inner-border-radius: calc(var(--bs-border-radius-lg) - var(--bs-border-width));
-  --bs-popover-box-shadow: var(--bs-box-shadow);
-  --bs-popover-header-padding-x: 1rem;
-  --bs-popover-header-padding-y: 0.5rem;
-  --bs-popover-header-font-size: 0.875rem;
-  --bs-popover-header-color: inherit;
-  --bs-popover-header-bg: var(--bs-secondary-bg);
-  --bs-popover-body-padding-x: 1rem;
-  --bs-popover-body-padding-y: 1rem;
-  --bs-popover-body-color: var(--bs-body-color);
-  --bs-popover-arrow-width: 1rem;
-  --bs-popover-arrow-height: 0.5rem;
-  --bs-popover-arrow-border: var(--bs-popover-border-color);
-  z-index: var(--bs-popover-zindex);
-  display: block;
-  max-width: var(--bs-popover-max-width);
-  font-family: var(--bs-font-sans-serif);
-  font-style: normal;
-  font-weight: 400;
-  line-height: 1.5;
-  text-align: left;
-  text-align: start;
-  text-decoration: none;
-  text-shadow: none;
-  text-transform: none;
-  letter-spacing: normal;
-  word-break: normal;
-  white-space: normal;
-  word-spacing: normal;
-  line-break: auto;
-  font-size: var(--bs-popover-font-size);
-  word-wrap: break-word;
-  background-color: var(--bs-popover-bg);
-  background-clip: padding-box;
-  border: var(--bs-popover-border-width) solid var(--bs-popover-border-color);
-  border-radius: var(--bs-popover-border-radius);
-}
-.popover .popover-arrow {
-  display: block;
-  width: var(--bs-popover-arrow-width);
-  height: var(--bs-popover-arrow-height);
-}
-.popover .popover-arrow::before, .popover .popover-arrow::after {
-  position: absolute;
-  display: block;
-  content: "";
-  border-color: transparent;
-  border-style: solid;
-  border-width: 0;
+    --bs-popover-font-size: 0.765625rem;
+    --bs-popover-header-font-size: 0.875rem;
+    font-size: var(--bs-popover-font-size);
 }
 
-.bs-popover-top > .popover-arrow, .bs-popover-auto[data-popper-placement^=top] > .popover-arrow {
-  bottom: calc(-1 * (var(--bs-popover-arrow-height)) - var(--bs-popover-border-width));
-}
-.bs-popover-top > .popover-arrow::before, .bs-popover-auto[data-popper-placement^=top] > .popover-arrow::before, .bs-popover-top > .popover-arrow::after, .bs-popover-auto[data-popper-placement^=top] > .popover-arrow::after {
-  border-width: var(--bs-popover-arrow-height) calc(var(--bs-popover-arrow-width) * 0.5) 0;
-}
-.bs-popover-top > .popover-arrow::before, .bs-popover-auto[data-popper-placement^=top] > .popover-arrow::before {
-  bottom: 0;
-  border-top-color: var(--bs-popover-arrow-border);
-}
-.bs-popover-top > .popover-arrow::after, .bs-popover-auto[data-popper-placement^=top] > .popover-arrow::after {
-  bottom: var(--bs-popover-border-width);
-  border-top-color: var(--bs-popover-bg);
-}
-
-/* rtl:begin:ignore */
-.bs-popover-end > .popover-arrow, .bs-popover-auto[data-popper-placement^=right] > .popover-arrow {
-  left: calc(-1 * (var(--bs-popover-arrow-height)) - var(--bs-popover-border-width));
-  width: var(--bs-popover-arrow-height);
-  height: var(--bs-popover-arrow-width);
-}
-.bs-popover-end > .popover-arrow::before, .bs-popover-auto[data-popper-placement^=right] > .popover-arrow::before, .bs-popover-end > .popover-arrow::after, .bs-popover-auto[data-popper-placement^=right] > .popover-arrow::after {
-  border-width: calc(var(--bs-popover-arrow-width) * 0.5) var(--bs-popover-arrow-height) calc(var(--bs-popover-arrow-width) * 0.5) 0;
-}
-.bs-popover-end > .popover-arrow::before, .bs-popover-auto[data-popper-placement^=right] > .popover-arrow::before {
-  left: 0;
-  border-right-color: var(--bs-popover-arrow-border);
-}
-.bs-popover-end > .popover-arrow::after, .bs-popover-auto[data-popper-placement^=right] > .popover-arrow::after {
-  left: var(--bs-popover-border-width);
-  border-right-color: var(--bs-popover-bg);
-}
-
-/* rtl:end:ignore */
-.bs-popover-bottom > .popover-arrow, .bs-popover-auto[data-popper-placement^=bottom] > .popover-arrow {
-  top: calc(-1 * (var(--bs-popover-arrow-height)) - var(--bs-popover-border-width));
-}
-.bs-popover-bottom > .popover-arrow::before, .bs-popover-auto[data-popper-placement^=bottom] > .popover-arrow::before, .bs-popover-bottom > .popover-arrow::after, .bs-popover-auto[data-popper-placement^=bottom] > .popover-arrow::after {
-  border-width: 0 calc(var(--bs-popover-arrow-width) * 0.5) var(--bs-popover-arrow-height);
-}
-.bs-popover-bottom > .popover-arrow::before, .bs-popover-auto[data-popper-placement^=bottom] > .popover-arrow::before {
-  top: 0;
-  border-bottom-color: var(--bs-popover-arrow-border);
-}
-.bs-popover-bottom > .popover-arrow::after, .bs-popover-auto[data-popper-placement^=bottom] > .popover-arrow::after {
-  top: var(--bs-popover-border-width);
-  border-bottom-color: var(--bs-popover-bg);
-}
-.bs-popover-bottom .popover-header::before, .bs-popover-auto[data-popper-placement^=bottom] .popover-header::before {
-  position: absolute;
-  top: 0;
-  left: 50%;
-  display: block;
-  width: var(--bs-popover-arrow-width);
-  margin-left: calc(-0.5 * var(--bs-popover-arrow-width));
-  content: "";
-  border-bottom: var(--bs-popover-border-width) solid var(--bs-popover-header-bg);
-}
-
-/* rtl:begin:ignore */
-.bs-popover-start > .popover-arrow, .bs-popover-auto[data-popper-placement^=left] > .popover-arrow {
-  right: calc(-1 * (var(--bs-popover-arrow-height)) - var(--bs-popover-border-width));
-  width: var(--bs-popover-arrow-height);
-  height: var(--bs-popover-arrow-width);
-}
-.bs-popover-start > .popover-arrow::before, .bs-popover-auto[data-popper-placement^=left] > .popover-arrow::before, .bs-popover-start > .popover-arrow::after, .bs-popover-auto[data-popper-placement^=left] > .popover-arrow::after {
-  border-width: calc(var(--bs-popover-arrow-width) * 0.5) 0 calc(var(--bs-popover-arrow-width) * 0.5) var(--bs-popover-arrow-height);
-}
-.bs-popover-start > .popover-arrow::before, .bs-popover-auto[data-popper-placement^=left] > .popover-arrow::before {
-  right: 0;
-  border-left-color: var(--bs-popover-arrow-border);
-}
-.bs-popover-start > .popover-arrow::after, .bs-popover-auto[data-popper-placement^=left] > .popover-arrow::after {
-  right: var(--bs-popover-border-width);
-  border-left-color: var(--bs-popover-bg);
-}
-
-/* rtl:end:ignore */
 .popover-header {
-  padding: var(--bs-popover-header-padding-y) var(--bs-popover-header-padding-x);
-  margin-bottom: 0;
-  font-size: var(--bs-popover-header-font-size);
-  color: var(--bs-popover-header-color);
-  background-color: var(--bs-popover-header-bg);
-  border-bottom: var(--bs-popover-border-width) solid var(--bs-popover-border-color);
-  border-top-left-radius: var(--bs-popover-inner-border-radius);
-  border-top-right-radius: var(--bs-popover-inner-border-radius);
-}
-.popover-header:empty {
-  display: none;
+    font-size: var(--bs-popover-header-font-size);
 }
 
-.popover-body {
-  padding: var(--bs-popover-body-padding-y) var(--bs-popover-body-padding-x);
-  color: var(--bs-popover-body-color);
-}
-
-.carousel {
-  position: relative;
-}
-
-.carousel.pointer-event {
-  touch-action: pan-y;
-}
-
-.carousel-inner {
-  position: relative;
-  width: 100%;
-  overflow: hidden;
-}
-.carousel-inner::after {
-  display: block;
-  clear: both;
-  content: "";
-}
 
 .carousel-item {
-  position: relative;
-  display: none;
-  float: left;
-  width: 100%;
-  margin-right: -100%;
-  backface-visibility: hidden;
-  transition: transform 0.6s ease-in-out;
-}
-@media (prefers-reduced-motion: reduce) {
-  .carousel-item {
-    transition: none;
-  }
-}
-
-.carousel-item.active,
-.carousel-item-next,
-.carousel-item-prev {
-  display: block;
-}
-
-.carousel-item-next:not(.carousel-item-start),
-.active.carousel-item-end {
-  transform: translateX(100%);
-}
-
-.carousel-item-prev:not(.carousel-item-end),
-.active.carousel-item-start {
-  transform: translateX(-100%);
-}
-
-.carousel-fade .carousel-item {
-  opacity: 0;
-  transition-property: opacity;
-  transform: none;
-}
-.carousel-fade .carousel-item.active,
-.carousel-fade .carousel-item-next.carousel-item-start,
-.carousel-fade .carousel-item-prev.carousel-item-end {
-  z-index: 1;
-  opacity: 1;
-}
-.carousel-fade .active.carousel-item-start,
-.carousel-fade .active.carousel-item-end {
-  z-index: 0;
-  opacity: 0;
-  transition: opacity 0s 0.6s;
-}
-@media (prefers-reduced-motion: reduce) {
-  .carousel-fade .active.carousel-item-start,
-  .carousel-fade .active.carousel-item-end {
-    transition: none;
-  }
-}
-
-.carousel-control-prev,
-.carousel-control-next {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  z-index: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 15%;
-  padding: 0;
-  color: #fff;
-  text-align: center;
-  background: none;
-  border: 0;
-  opacity: 0.5;
-  transition: opacity 0.15s ease;
-}
-@media (prefers-reduced-motion: reduce) {
-  .carousel-control-prev,
-  .carousel-control-next {
-    transition: none;
-  }
-}
-.carousel-control-prev:hover, .carousel-control-prev:focus,
-.carousel-control-next:hover,
-.carousel-control-next:focus {
-  color: #fff;
-  text-decoration: none;
-  outline: 0;
-  opacity: 0.9;
-}
-
-.carousel-control-prev {
-  left: 0;
-}
-
-.carousel-control-next {
-  right: 0;
-}
-
-.carousel-control-prev-icon,
-.carousel-control-next-icon {
-  display: inline-block;
-  width: 2rem;
-  height: 2rem;
-  background-repeat: no-repeat;
-  background-position: 50%;
-  background-size: 100% 100%;
-}
-
-/* rtl:options: {
-  "autoRename": true,
-  "stringMap":[ {
-    "name"    : "prev-next",
-    "search"  : "prev",
-    "replace" : "next"
-  } ]
-} */
-.carousel-control-prev-icon {
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23fff'%3e%3cpath d='M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z'/%3e%3c/svg%3e");
-}
-
-.carousel-control-next-icon {
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23fff'%3e%3cpath d='M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
-}
-
-.carousel-indicators {
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 2;
-  display: flex;
-  justify-content: center;
-  padding: 0;
-  margin-right: 15%;
-  margin-bottom: 1rem;
-  margin-left: 15%;
-}
-.carousel-indicators [data-bs-target] {
-  box-sizing: content-box;
-  flex: 0 1 auto;
-  width: 30px;
-  height: 3px;
-  padding: 0;
-  margin-right: 3px;
-  margin-left: 3px;
-  text-indent: -999px;
-  cursor: pointer;
-  background-color: #fff;
-  background-clip: padding-box;
-  border: 0;
-  border-top: 10px solid transparent;
-  border-bottom: 10px solid transparent;
-  opacity: 0.5;
-  transition: opacity 0.6s ease;
-}
-@media (prefers-reduced-motion: reduce) {
-  .carousel-indicators [data-bs-target] {
-    transition: none;
-  }
-}
-.carousel-indicators .active {
-  opacity: 1;
-}
-
-.carousel-caption {
-  position: absolute;
-  right: 15%;
-  bottom: 1.25rem;
-  left: 15%;
-  padding-top: 1.25rem;
-  padding-bottom: 1.25rem;
-  color: #fff;
-  text-align: center;
-}
-
-.carousel-dark .carousel-control-prev-icon,
-.carousel-dark .carousel-control-next-icon {
-  filter: invert(1) grayscale(100);
-}
-.carousel-dark .carousel-indicators [data-bs-target] {
-  background-color: #000;
-}
-.carousel-dark .carousel-caption {
-  color: #000;
-}
-
-[data-bs-theme=dark] .carousel .carousel-control-prev-icon,
-[data-bs-theme=dark] .carousel .carousel-control-next-icon, [data-bs-theme=dark].carousel .carousel-control-prev-icon,
-[data-bs-theme=dark].carousel .carousel-control-next-icon {
-  filter: invert(1) grayscale(100);
-}
-[data-bs-theme=dark] .carousel .carousel-indicators [data-bs-target], [data-bs-theme=dark].carousel .carousel-indicators [data-bs-target] {
-  background-color: #000;
-}
-[data-bs-theme=dark] .carousel .carousel-caption, [data-bs-theme=dark].carousel .carousel-caption {
-  color: #000;
-}
-
-.spinner-grow,
-.spinner-border {
-  display: inline-block;
-  width: var(--bs-spinner-width);
-  height: var(--bs-spinner-height);
-  vertical-align: var(--bs-spinner-vertical-align);
-  border-radius: 50%;
-  animation: var(--bs-spinner-animation-speed) linear infinite var(--bs-spinner-animation-name);
-}
-
-@keyframes spinner-border {
-  to {
-    transform: rotate(360deg) /* rtl:ignore */;
-  }
-}
-.spinner-border {
-  --bs-spinner-width: 2rem;
-  --bs-spinner-height: 2rem;
-  --bs-spinner-vertical-align: -0.125em;
-  --bs-spinner-border-width: 0.25em;
-  --bs-spinner-animation-speed: 0.75s;
-  --bs-spinner-animation-name: spinner-border;
-  border: var(--bs-spinner-border-width) solid currentcolor;
-  border-right-color: transparent;
-}
-
-.spinner-border-sm {
-  --bs-spinner-width: 1rem;
-  --bs-spinner-height: 1rem;
-  --bs-spinner-border-width: 0.2em;
-}
-
-@keyframes spinner-grow {
-  0% {
-    transform: scale(0);
-  }
-  50% {
-    opacity: 1;
-    transform: none;
-  }
-}
-.spinner-grow {
-  --bs-spinner-width: 2rem;
-  --bs-spinner-height: 2rem;
-  --bs-spinner-vertical-align: -0.125em;
-  --bs-spinner-animation-speed: 0.75s;
-  --bs-spinner-animation-name: spinner-grow;
-  background-color: currentcolor;
-  opacity: 0;
-}
-
-.spinner-grow-sm {
-  --bs-spinner-width: 1rem;
-  --bs-spinner-height: 1rem;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .spinner-border,
-  .spinner-grow {
-    --bs-spinner-animation-speed: 1.5s;
-  }
-}
-.offcanvas, .offcanvas-xxl, .offcanvas-xl, .offcanvas-lg, .offcanvas-md, .offcanvas-sm {
-  --bs-offcanvas-zindex: 1045;
-  --bs-offcanvas-width: 400px;
-  --bs-offcanvas-height: 30vh;
-  --bs-offcanvas-padding-x: 1rem;
-  --bs-offcanvas-padding-y: 1rem;
-  --bs-offcanvas-color: var(--bs-body-color);
-  --bs-offcanvas-bg: var(--bs-body-bg);
-  --bs-offcanvas-border-width: var(--bs-border-width);
-  --bs-offcanvas-border-color: var(--bs-border-color-translucent);
-  --bs-offcanvas-box-shadow: var(--bs-box-shadow-sm);
-  --bs-offcanvas-transition: transform 0.3s ease-in-out;
-  --bs-offcanvas-title-line-height: 1.5;
-}
-
-@media (max-width: 575.98px) {
-  .offcanvas-sm {
-    position: fixed;
-    bottom: 0;
-    z-index: var(--bs-offcanvas-zindex);
-    display: flex;
-    flex-direction: column;
-    max-width: 100%;
-    color: var(--bs-offcanvas-color);
-    visibility: hidden;
-    background-color: var(--bs-offcanvas-bg);
-    background-clip: padding-box;
-    outline: 0;
-    transition: var(--bs-offcanvas-transition);
-  }
-}
-@media (max-width: 575.98px) and (prefers-reduced-motion: reduce) {
-  .offcanvas-sm {
-    transition: none;
-  }
-}
-@media (max-width: 575.98px) {
-  .offcanvas-sm.offcanvas-start {
-    top: 0;
-    left: 0;
-    width: var(--bs-offcanvas-width);
-    border-right: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-    transform: translateX(-100%);
-  }
-  .offcanvas-sm.offcanvas-end {
-    top: 0;
-    right: 0;
-    width: var(--bs-offcanvas-width);
-    border-left: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-    transform: translateX(100%);
-  }
-  .offcanvas-sm.offcanvas-top {
-    top: 0;
-    right: 0;
-    left: 0;
-    height: var(--bs-offcanvas-height);
-    max-height: 100%;
-    border-bottom: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-    transform: translateY(-100%);
-  }
-  .offcanvas-sm.offcanvas-bottom {
-    right: 0;
-    left: 0;
-    height: var(--bs-offcanvas-height);
-    max-height: 100%;
-    border-top: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-    transform: translateY(100%);
-  }
-  .offcanvas-sm.showing, .offcanvas-sm.show:not(.hiding) {
-    transform: none;
-  }
-  .offcanvas-sm.showing, .offcanvas-sm.hiding, .offcanvas-sm.show {
-    visibility: visible;
-  }
-}
-@media (min-width: 576px) {
-  .offcanvas-sm {
-    --bs-offcanvas-height: auto;
-    --bs-offcanvas-border-width: 0;
-    background-color: transparent !important;
-  }
-  .offcanvas-sm .offcanvas-header {
-    display: none;
-  }
-  .offcanvas-sm .offcanvas-body {
-    display: flex;
-    flex-grow: 0;
-    padding: 0;
-    overflow-y: visible;
-    background-color: transparent !important;
-  }
-}
-
-@media (max-width: 767.98px) {
-  .offcanvas-md {
-    position: fixed;
-    bottom: 0;
-    z-index: var(--bs-offcanvas-zindex);
-    display: flex;
-    flex-direction: column;
-    max-width: 100%;
-    color: var(--bs-offcanvas-color);
-    visibility: hidden;
-    background-color: var(--bs-offcanvas-bg);
-    background-clip: padding-box;
-    outline: 0;
-    transition: var(--bs-offcanvas-transition);
-  }
-}
-@media (max-width: 767.98px) and (prefers-reduced-motion: reduce) {
-  .offcanvas-md {
-    transition: none;
-  }
-}
-@media (max-width: 767.98px) {
-  .offcanvas-md.offcanvas-start {
-    top: 0;
-    left: 0;
-    width: var(--bs-offcanvas-width);
-    border-right: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-    transform: translateX(-100%);
-  }
-  .offcanvas-md.offcanvas-end {
-    top: 0;
-    right: 0;
-    width: var(--bs-offcanvas-width);
-    border-left: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-    transform: translateX(100%);
-  }
-  .offcanvas-md.offcanvas-top {
-    top: 0;
-    right: 0;
-    left: 0;
-    height: var(--bs-offcanvas-height);
-    max-height: 100%;
-    border-bottom: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-    transform: translateY(-100%);
-  }
-  .offcanvas-md.offcanvas-bottom {
-    right: 0;
-    left: 0;
-    height: var(--bs-offcanvas-height);
-    max-height: 100%;
-    border-top: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-    transform: translateY(100%);
-  }
-  .offcanvas-md.showing, .offcanvas-md.show:not(.hiding) {
-    transform: none;
-  }
-  .offcanvas-md.showing, .offcanvas-md.hiding, .offcanvas-md.show {
-    visibility: visible;
-  }
-}
-@media (min-width: 768px) {
-  .offcanvas-md {
-    --bs-offcanvas-height: auto;
-    --bs-offcanvas-border-width: 0;
-    background-color: transparent !important;
-  }
-  .offcanvas-md .offcanvas-header {
-    display: none;
-  }
-  .offcanvas-md .offcanvas-body {
-    display: flex;
-    flex-grow: 0;
-    padding: 0;
-    overflow-y: visible;
-    background-color: transparent !important;
-  }
-}
-
-@media (max-width: 991.98px) {
-  .offcanvas-lg {
-    position: fixed;
-    bottom: 0;
-    z-index: var(--bs-offcanvas-zindex);
-    display: flex;
-    flex-direction: column;
-    max-width: 100%;
-    color: var(--bs-offcanvas-color);
-    visibility: hidden;
-    background-color: var(--bs-offcanvas-bg);
-    background-clip: padding-box;
-    outline: 0;
-    transition: var(--bs-offcanvas-transition);
-  }
-}
-@media (max-width: 991.98px) and (prefers-reduced-motion: reduce) {
-  .offcanvas-lg {
-    transition: none;
-  }
-}
-@media (max-width: 991.98px) {
-  .offcanvas-lg.offcanvas-start {
-    top: 0;
-    left: 0;
-    width: var(--bs-offcanvas-width);
-    border-right: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-    transform: translateX(-100%);
-  }
-  .offcanvas-lg.offcanvas-end {
-    top: 0;
-    right: 0;
-    width: var(--bs-offcanvas-width);
-    border-left: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-    transform: translateX(100%);
-  }
-  .offcanvas-lg.offcanvas-top {
-    top: 0;
-    right: 0;
-    left: 0;
-    height: var(--bs-offcanvas-height);
-    max-height: 100%;
-    border-bottom: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-    transform: translateY(-100%);
-  }
-  .offcanvas-lg.offcanvas-bottom {
-    right: 0;
-    left: 0;
-    height: var(--bs-offcanvas-height);
-    max-height: 100%;
-    border-top: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-    transform: translateY(100%);
-  }
-  .offcanvas-lg.showing, .offcanvas-lg.show:not(.hiding) {
-    transform: none;
-  }
-  .offcanvas-lg.showing, .offcanvas-lg.hiding, .offcanvas-lg.show {
-    visibility: visible;
-  }
-}
-@media (min-width: 992px) {
-  .offcanvas-lg {
-    --bs-offcanvas-height: auto;
-    --bs-offcanvas-border-width: 0;
-    background-color: transparent !important;
-  }
-  .offcanvas-lg .offcanvas-header {
-    display: none;
-  }
-  .offcanvas-lg .offcanvas-body {
-    display: flex;
-    flex-grow: 0;
-    padding: 0;
-    overflow-y: visible;
-    background-color: transparent !important;
-  }
-}
-
-@media (max-width: 1199.98px) {
-  .offcanvas-xl {
-    position: fixed;
-    bottom: 0;
-    z-index: var(--bs-offcanvas-zindex);
-    display: flex;
-    flex-direction: column;
-    max-width: 100%;
-    color: var(--bs-offcanvas-color);
-    visibility: hidden;
-    background-color: var(--bs-offcanvas-bg);
-    background-clip: padding-box;
-    outline: 0;
-    transition: var(--bs-offcanvas-transition);
-  }
-}
-@media (max-width: 1199.98px) and (prefers-reduced-motion: reduce) {
-  .offcanvas-xl {
-    transition: none;
-  }
-}
-@media (max-width: 1199.98px) {
-  .offcanvas-xl.offcanvas-start {
-    top: 0;
-    left: 0;
-    width: var(--bs-offcanvas-width);
-    border-right: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-    transform: translateX(-100%);
-  }
-  .offcanvas-xl.offcanvas-end {
-    top: 0;
-    right: 0;
-    width: var(--bs-offcanvas-width);
-    border-left: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-    transform: translateX(100%);
-  }
-  .offcanvas-xl.offcanvas-top {
-    top: 0;
-    right: 0;
-    left: 0;
-    height: var(--bs-offcanvas-height);
-    max-height: 100%;
-    border-bottom: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-    transform: translateY(-100%);
-  }
-  .offcanvas-xl.offcanvas-bottom {
-    right: 0;
-    left: 0;
-    height: var(--bs-offcanvas-height);
-    max-height: 100%;
-    border-top: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-    transform: translateY(100%);
-  }
-  .offcanvas-xl.showing, .offcanvas-xl.show:not(.hiding) {
-    transform: none;
-  }
-  .offcanvas-xl.showing, .offcanvas-xl.hiding, .offcanvas-xl.show {
-    visibility: visible;
-  }
-}
-@media (min-width: 1200px) {
-  .offcanvas-xl {
-    --bs-offcanvas-height: auto;
-    --bs-offcanvas-border-width: 0;
-    background-color: transparent !important;
-  }
-  .offcanvas-xl .offcanvas-header {
-    display: none;
-  }
-  .offcanvas-xl .offcanvas-body {
-    display: flex;
-    flex-grow: 0;
-    padding: 0;
-    overflow-y: visible;
-    background-color: transparent !important;
-  }
-}
-
-@media (max-width: 1399.98px) {
-  .offcanvas-xxl {
-    position: fixed;
-    bottom: 0;
-    z-index: var(--bs-offcanvas-zindex);
-    display: flex;
-    flex-direction: column;
-    max-width: 100%;
-    color: var(--bs-offcanvas-color);
-    visibility: hidden;
-    background-color: var(--bs-offcanvas-bg);
-    background-clip: padding-box;
-    outline: 0;
-    transition: var(--bs-offcanvas-transition);
-  }
-}
-@media (max-width: 1399.98px) and (prefers-reduced-motion: reduce) {
-  .offcanvas-xxl {
-    transition: none;
-  }
-}
-@media (max-width: 1399.98px) {
-  .offcanvas-xxl.offcanvas-start {
-    top: 0;
-    left: 0;
-    width: var(--bs-offcanvas-width);
-    border-right: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-    transform: translateX(-100%);
-  }
-  .offcanvas-xxl.offcanvas-end {
-    top: 0;
-    right: 0;
-    width: var(--bs-offcanvas-width);
-    border-left: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-    transform: translateX(100%);
-  }
-  .offcanvas-xxl.offcanvas-top {
-    top: 0;
-    right: 0;
-    left: 0;
-    height: var(--bs-offcanvas-height);
-    max-height: 100%;
-    border-bottom: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-    transform: translateY(-100%);
-  }
-  .offcanvas-xxl.offcanvas-bottom {
-    right: 0;
-    left: 0;
-    height: var(--bs-offcanvas-height);
-    max-height: 100%;
-    border-top: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-    transform: translateY(100%);
-  }
-  .offcanvas-xxl.showing, .offcanvas-xxl.show:not(.hiding) {
-    transform: none;
-  }
-  .offcanvas-xxl.showing, .offcanvas-xxl.hiding, .offcanvas-xxl.show {
-    visibility: visible;
-  }
-}
-@media (min-width: 1400px) {
-  .offcanvas-xxl {
-    --bs-offcanvas-height: auto;
-    --bs-offcanvas-border-width: 0;
-    background-color: transparent !important;
-  }
-  .offcanvas-xxl .offcanvas-header {
-    display: none;
-  }
-  .offcanvas-xxl .offcanvas-body {
-    display: flex;
-    flex-grow: 0;
-    padding: 0;
-    overflow-y: visible;
-    background-color: transparent !important;
-  }
-}
-
-.offcanvas {
-  position: fixed;
-  bottom: 0;
-  z-index: var(--bs-offcanvas-zindex);
-  display: flex;
-  flex-direction: column;
-  max-width: 100%;
-  color: var(--bs-offcanvas-color);
-  visibility: hidden;
-  background-color: var(--bs-offcanvas-bg);
-  background-clip: padding-box;
-  outline: 0;
-  transition: var(--bs-offcanvas-transition);
-}
-@media (prefers-reduced-motion: reduce) {
-  .offcanvas {
-    transition: none;
-  }
-}
-.offcanvas.offcanvas-start {
-  top: 0;
-  left: 0;
-  width: var(--bs-offcanvas-width);
-  border-right: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-  transform: translateX(-100%);
-}
-.offcanvas.offcanvas-end {
-  top: 0;
-  right: 0;
-  width: var(--bs-offcanvas-width);
-  border-left: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-  transform: translateX(100%);
-}
-.offcanvas.offcanvas-top {
-  top: 0;
-  right: 0;
-  left: 0;
-  height: var(--bs-offcanvas-height);
-  max-height: 100%;
-  border-bottom: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-  transform: translateY(-100%);
-}
-.offcanvas.offcanvas-bottom {
-  right: 0;
-  left: 0;
-  height: var(--bs-offcanvas-height);
-  max-height: 100%;
-  border-top: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
-  transform: translateY(100%);
-}
-.offcanvas.showing, .offcanvas.show:not(.hiding) {
-  transform: none;
-}
-.offcanvas.showing, .offcanvas.hiding, .offcanvas.show {
-  visibility: visible;
-}
-
-.offcanvas-backdrop {
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: 1040;
-  width: 100vw;
-  height: 100vh;
-  background-color: #000;
-}
-.offcanvas-backdrop.fade {
-  opacity: 0;
-}
-.offcanvas-backdrop.show {
-  opacity: 0.5;
-}
-
-.offcanvas-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--bs-offcanvas-padding-y) var(--bs-offcanvas-padding-x);
-}
-.offcanvas-header .btn-close {
-  padding: calc(var(--bs-offcanvas-padding-y) * 0.5) calc(var(--bs-offcanvas-padding-x) * 0.5);
-  margin-top: calc(-0.5 * var(--bs-offcanvas-padding-y));
-  margin-right: calc(-0.5 * var(--bs-offcanvas-padding-x));
-  margin-bottom: calc(-0.5 * var(--bs-offcanvas-padding-y));
-}
-
-.offcanvas-title {
-  margin-bottom: 0;
-  line-height: var(--bs-offcanvas-title-line-height);
-}
-
-.offcanvas-body {
-  flex-grow: 1;
-  padding: var(--bs-offcanvas-padding-y) var(--bs-offcanvas-padding-x);
-  overflow-y: auto;
-}
-
-.placeholder {
-  display: inline-block;
-  min-height: 1em;
-  vertical-align: middle;
-  cursor: wait;
-  background-color: currentcolor;
-  opacity: 0.5;
-}
-.placeholder.btn::before {
-  display: inline-block;
-  content: "";
-}
-
-.placeholder-xs {
-  min-height: 0.6em;
-}
-
-.placeholder-sm {
-  min-height: 0.8em;
-}
-
-.placeholder-lg {
-  min-height: 1.2em;
-}
-
-.placeholder-glow .placeholder {
-  animation: placeholder-glow 2s ease-in-out infinite;
-}
-
-@keyframes placeholder-glow {
-  50% {
-    opacity: 0.2;
-  }
-}
-.placeholder-wave {
-  -webkit-mask-image: linear-gradient(130deg, #000 55%, rgba(0, 0, 0, 0.8) 75%, #000 95%);
-          mask-image: linear-gradient(130deg, #000 55%, rgba(0, 0, 0, 0.8) 75%, #000 95%);
-  -webkit-mask-size: 200% 100%;
-          mask-size: 200% 100%;
-  animation: placeholder-wave 2s linear infinite;
-}
-
-@keyframes placeholder-wave {
-  100% {
-    -webkit-mask-position: -200% 0%;
-            mask-position: -200% 0%;
-  }
-}
-.clearfix::after {
-  display: block;
-  clear: both;
-  content: "";
-}
-
-.text-bg-primary {
-  color: #fff !important;
-  background-color: RGBA(var(--bs-primary-rgb), var(--bs-bg-opacity, 1)) !important;
-}
-
-.text-bg-secondary {
-  color: #fff !important;
-  background-color: RGBA(var(--bs-secondary-rgb), var(--bs-bg-opacity, 1)) !important;
-}
-
-.text-bg-success {
-  color: #fff !important;
-  background-color: RGBA(var(--bs-success-rgb), var(--bs-bg-opacity, 1)) !important;
+    -webkit-backface-visibility: initial;
 }
 
 .text-bg-info {
-  color: #fff !important;
-  background-color: RGBA(var(--bs-info-rgb), var(--bs-bg-opacity, 1)) !important;
+    color: #fff !important;
 }
 
-.text-bg-warning {
-  color: #000 !important;
-  background-color: RGBA(var(--bs-warning-rgb), var(--bs-bg-opacity, 1)) !important;
+.link-primary:hover,
+.link-primary:focus {
+    color: RGBA(65, 58, 183, var(--bs-link-opacity, 1)) !important;
+    text-decoration-color: RGBA(65, 58, 183, var(--bs-link-underline-opacity, 1)) !important;
 }
 
-.text-bg-danger {
-  color: #fff !important;
-  background-color: RGBA(var(--bs-danger-rgb), var(--bs-bg-opacity, 1)) !important;
+.link-secondary:hover,
+.link-secondary:focus {
+    color: RGBA(122, 40, 185, var(--bs-link-opacity, 1)) !important;
+    text-decoration-color: RGBA(122, 40, 185, var(--bs-link-underline-opacity, 1)) !important;
 }
 
-.text-bg-light {
-  color: #000 !important;
-  background-color: RGBA(var(--bs-light-rgb), var(--bs-bg-opacity, 1)) !important;
+.link-success:hover,
+.link-success:focus {
+    color: RGBA(4, 142, 90, var(--bs-link-opacity, 1)) !important;
+    text-decoration-color: RGBA(4, 142, 90, var(--bs-link-underline-opacity, 1)) !important;
 }
 
-.text-bg-dark {
-  color: #fff !important;
-  background-color: RGBA(var(--bs-dark-rgb), var(--bs-bg-opacity, 1)) !important;
-}
-
-.link-primary {
-  color: RGBA(var(--bs-primary-rgb), var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(var(--bs-primary-rgb), var(--bs-link-underline-opacity, 1)) !important;
-}
-.link-primary:hover, .link-primary:focus {
-  color: RGBA(65, 58, 183, var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(65, 58, 183, var(--bs-link-underline-opacity, 1)) !important;
-}
-
-.link-secondary {
-  color: RGBA(var(--bs-secondary-rgb), var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(var(--bs-secondary-rgb), var(--bs-link-underline-opacity, 1)) !important;
-}
-.link-secondary:hover, .link-secondary:focus {
-  color: RGBA(122, 40, 185, var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(122, 40, 185, var(--bs-link-underline-opacity, 1)) !important;
-}
-
-.link-success {
-  color: RGBA(var(--bs-success-rgb), var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(var(--bs-success-rgb), var(--bs-link-underline-opacity, 1)) !important;
-}
-.link-success:hover, .link-success:focus {
-  color: RGBA(4, 142, 90, var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(4, 142, 90, var(--bs-link-underline-opacity, 1)) !important;
-}
-
-.link-info {
-  color: RGBA(var(--bs-info-rgb), var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(var(--bs-info-rgb), var(--bs-link-underline-opacity, 1)) !important;
-}
-.link-info:hover, .link-info:focus {
-  color: RGBA(30, 155, 182, var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(30, 155, 182, var(--bs-link-underline-opacity, 1)) !important;
+.link-info:hover,
+.link-info:focus {
+    color: RGBA(30, 155, 182, var(--bs-link-opacity, 1)) !important;
+    text-decoration-color: RGBA(30, 155, 182, var(--bs-link-underline-opacity, 1)) !important;
 }
 
 .link-warning {
-  color: RGBA(var(--bs-warning-rgb), var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(var(--bs-warning-rgb), var(--bs-link-underline-opacity, 1)) !important;
+    -webkit-text-decoration-color: initial;
+    color: RGBA(var(--bs-warning-rgb), var(--bs-link-opacity, 1)) !important;
+    text-decoration-color: RGBA(var(--bs-warning-rgb), var(--bs-link-underline-opacity, 1)) !important;
 }
-.link-warning:hover, .link-warning:focus {
-  color: RGBA(251, 190, 104, var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(251, 190, 104, var(--bs-link-underline-opacity, 1)) !important;
+
+.link-warning:hover,
+.link-warning:focus {
+    -webkit-text-decoration-color: initial;
+    color: RGBA(251, 190, 104, var(--bs-link-opacity, 1)) !important;
+    text-decoration-color: RGBA(251, 190, 104, var(--bs-link-underline-opacity, 1)) !important;
 }
+
 
 .link-danger {
-  color: RGBA(var(--bs-danger-rgb), var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(var(--bs-danger-rgb), var(--bs-link-underline-opacity, 1)) !important;
-}
-.link-danger:hover, .link-danger:focus {
-  color: RGBA(187, 54, 54, var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(187, 54, 54, var(--bs-link-underline-opacity, 1)) !important;
+    -webkit-text-decoration-color: initial;
+    color: RGBA(var(--bs-danger-rgb), var(--bs-link-opacity, 1)) !important;
+    text-decoration-color: RGBA(var(--bs-danger-rgb), var(--bs-link-underline-opacity, 1)) !important;
 }
 
-.link-light {
-  color: RGBA(var(--bs-light-rgb), var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(var(--bs-light-rgb), var(--bs-link-underline-opacity, 1)) !important;
+.link-danger:hover,
+.link-danger:focus {
+    -webkit-text-decoration-color: initial;
+    color: RGBA(187, 54, 54, var(--bs-link-opacity, 1)) !important;
+    text-decoration-color: RGBA(187, 54, 54, var(--bs-link-underline-opacity, 1)) !important;
 }
-.link-light:hover, .link-light:focus {
-  color: RGBA(241, 241, 241, var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(241, 241, 241, var(--bs-link-underline-opacity, 1)) !important;
+
+
+.link-light {
+    -webkit-text-decoration-color: initial;
+    color: RGBA(var(--bs-light-rgb), var(--bs-link-opacity, 1)) !important;
+    text-decoration-color: RGBA(var(--bs-light-rgb), var(--bs-link-underline-opacity, 1)) !important;
+
+}
+
+.link-light:hover,
+.link-light:focus {
+    -webkit-text-decoration-color: initial;
+    color: RGBA(241, 241, 241, var(--bs-link-opacity, 1)) !important;
+    text-decoration-color: RGBA(241, 241, 241, var(--bs-link-underline-opacity, 1)) !important;
 }
 
 .link-dark {
-  color: RGBA(var(--bs-dark-rgb), var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(var(--bs-dark-rgb), var(--bs-link-underline-opacity, 1)) !important;
+    -webkit-text-decoration-color: initial;
+    color: RGBA(var(--bs-dark-rgb), var(--bs-link-opacity, 1)) !important;
+    text-decoration-color: RGBA(var(--bs-dark-rgb), var(--bs-link-underline-opacity, 1)) !important;
 }
-.link-dark:hover, .link-dark:focus {
-  color: RGBA(33, 39, 42, var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(33, 39, 42, var(--bs-link-underline-opacity, 1)) !important;
+
+.link-dark:hover,
+.link-dark:focus {
+    -webkit-text-decoration-color: initial;
+    color: RGBA(33, 39, 42, var(--bs-link-opacity, 1)) !important;
+    text-decoration-color: RGBA(33, 39, 42, var(--bs-link-underline-opacity, 1)) !important;
 }
+
 
 .link-body-emphasis {
-  color: RGBA(var(--bs-emphasis-color-rgb), var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(var(--bs-emphasis-color-rgb), var(--bs-link-underline-opacity, 1)) !important;
-}
-.link-body-emphasis:hover, .link-body-emphasis:focus {
-  color: RGBA(var(--bs-emphasis-color-rgb), var(--bs-link-opacity, 0.75)) !important;
-  text-decoration-color: RGBA(var(--bs-emphasis-color-rgb), var(--bs-link-underline-opacity, 0.75)) !important;
+    -webkit-text-decoration-color: initial;
+    color: RGBA(var(--bs-emphasis-color-rgb), var(--bs-link-opacity, 1)) !important;
+    text-decoration-color: RGBA(var(--bs-emphasis-color-rgb), var(--bs-link-underline-opacity, 1)) !important;
 }
 
-.focus-ring:focus {
-  outline: 0;
-  box-shadow: var(--bs-focus-ring-x, 0) var(--bs-focus-ring-y, 0) var(--bs-focus-ring-blur, 0) var(--bs-focus-ring-width) var(--bs-focus-ring-color);
+.link-body-emphasis:hover,
+.link-body-emphasis:focus {
+    -webkit-text-decoration-color: initial;
+    color: RGBA(var(--bs-emphasis-color-rgb), var(--bs-link-opacity, 0.75)) !important;
+    text-decoration-color: RGBA(var(--bs-emphasis-color-rgb), var(--bs-link-underline-opacity, 0.75)) !important;
 }
 
 .icon-link {
-  display: inline-flex;
-  gap: 0.375rem;
-  align-items: center;
-  text-decoration-color: rgba(var(--bs-link-color-rgb), var(--bs-link-opacity, 0.5));
-  text-underline-offset: 0.25em;
-  backface-visibility: hidden;
+    -webkit-text-decoration-color: initial;
+    -webkit-backface-visibility: initial;
 }
-.icon-link > .bi {
-  flex-shrink: 0;
-  width: 1em;
-  height: 1em;
-  fill: currentcolor;
-  transition: 0.2s ease-in-out transform;
-}
-@media (prefers-reduced-motion: reduce) {
-  .icon-link > .bi {
-    transition: none;
-  }
-}
-
-.icon-link-hover:hover > .bi, .icon-link-hover:focus-visible > .bi {
-  transform: var(--bs-icon-link-transform, translate3d(0.25em, 0, 0));
-}
-
-.ratio {
-  position: relative;
-  width: 100%;
-}
-.ratio::before {
-  display: block;
-  padding-top: var(--bs-aspect-ratio);
-  content: "";
-}
-.ratio > * {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-}
-
-.ratio-1x1 {
-  --bs-aspect-ratio: 100%;
-}
-
-.ratio-4x3 {
-  --bs-aspect-ratio: 75%;
-}
-
-.ratio-16x9 {
-  --bs-aspect-ratio: 56.25%;
-}
-
-.ratio-21x9 {
-  --bs-aspect-ratio: 42.8571428571%;
-}
-
-.fixed-top {
-  position: fixed;
-  top: 0;
-  right: 0;
-  left: 0;
-  z-index: 1030;
-}
-
-.fixed-bottom {
-  position: fixed;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 1030;
-}
-
-.sticky-top {
-  position: sticky;
-  top: 0;
-  z-index: 1020;
-}
-
-.sticky-bottom {
-  position: sticky;
-  bottom: 0;
-  z-index: 1020;
-}
-
-@media (min-width: 576px) {
-  .sticky-sm-top {
-    position: sticky;
-    top: 0;
-    z-index: 1020;
-  }
-  .sticky-sm-bottom {
-    position: sticky;
-    bottom: 0;
-    z-index: 1020;
-  }
-}
-@media (min-width: 768px) {
-  .sticky-md-top {
-    position: sticky;
-    top: 0;
-    z-index: 1020;
-  }
-  .sticky-md-bottom {
-    position: sticky;
-    bottom: 0;
-    z-index: 1020;
-  }
-}
-@media (min-width: 992px) {
-  .sticky-lg-top {
-    position: sticky;
-    top: 0;
-    z-index: 1020;
-  }
-  .sticky-lg-bottom {
-    position: sticky;
-    bottom: 0;
-    z-index: 1020;
-  }
-}
-@media (min-width: 1200px) {
-  .sticky-xl-top {
-    position: sticky;
-    top: 0;
-    z-index: 1020;
-  }
-  .sticky-xl-bottom {
-    position: sticky;
-    bottom: 0;
-    z-index: 1020;
-  }
-}
-@media (min-width: 1400px) {
-  .sticky-xxl-top {
-    position: sticky;
-    top: 0;
-    z-index: 1020;
-  }
-  .sticky-xxl-bottom {
-    position: sticky;
-    bottom: 0;
-    z-index: 1020;
-  }
-}
-.hstack {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  align-self: stretch;
-}
-
-.vstack {
-  display: flex;
-  flex: 1 1 auto;
-  flex-direction: column;
-  align-self: stretch;
-}
-
-.visually-hidden,
-.visually-hidden-focusable:not(:focus):not(:focus-within) {
-  width: 1px !important;
-  height: 1px !important;
-  padding: 0 !important;
-  margin: -1px !important;
-  overflow: hidden !important;
-  clip: rect(0, 0, 0, 0) !important;
-  white-space: nowrap !important;
-  border: 0 !important;
-}
-.visually-hidden:not(caption),
-.visually-hidden-focusable:not(:focus):not(:focus-within):not(caption) {
-  position: absolute !important;
-}
-
-.stretched-link::after {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 1;
-  content: "";
-}
-
-.text-truncate {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.vr {
-  display: inline-block;
-  align-self: stretch;
-  width: var(--bs-border-width);
-  min-height: 1em;
-  background-color: currentcolor;
-  opacity: 0.25;
-}
-
-.align-baseline {
-  vertical-align: baseline !important;
-}
-
-.align-top {
-  vertical-align: top !important;
-}
-
-.align-middle {
-  vertical-align: middle !important;
-}
-
-.align-bottom {
-  vertical-align: bottom !important;
-}
-
-.align-text-bottom {
-  vertical-align: text-bottom !important;
-}
-
-.align-text-top {
-  vertical-align: text-top !important;
-}
-
-.float-start {
-  float: left !important;
-}
-
-.float-end {
-  float: right !important;
-}
-
-.float-none {
-  float: none !important;
-}
-
-.object-fit-contain {
-  -o-object-fit: contain !important;
-     object-fit: contain !important;
-}
-
-.object-fit-cover {
-  -o-object-fit: cover !important;
-     object-fit: cover !important;
-}
-
-.object-fit-fill {
-  -o-object-fit: fill !important;
-     object-fit: fill !important;
-}
-
-.object-fit-scale {
-  -o-object-fit: scale-down !important;
-     object-fit: scale-down !important;
-}
-
-.object-fit-none {
-  -o-object-fit: none !important;
-     object-fit: none !important;
-}
-
-.opacity-0 {
-  opacity: 0 !important;
-}
-
-.opacity-25 {
-  opacity: 0.25 !important;
-}
-
-.opacity-50 {
-  opacity: 0.5 !important;
-}
-
-.opacity-75 {
-  opacity: 0.75 !important;
-}
-
-.opacity-100 {
-  opacity: 1 !important;
-}
-
-.overflow-auto {
-  overflow: auto !important;
-}
-
-.overflow-hidden {
-  overflow: hidden !important;
-}
-
-.overflow-visible {
-  overflow: visible !important;
-}
-
-.overflow-scroll {
-  overflow: scroll !important;
-}
-
-.overflow-x-auto {
-  overflow-x: auto !important;
-}
-
-.overflow-x-hidden {
-  overflow-x: hidden !important;
-}
-
-.overflow-x-visible {
-  overflow-x: visible !important;
-}
-
-.overflow-x-scroll {
-  overflow-x: scroll !important;
-}
-
-.overflow-y-auto {
-  overflow-y: auto !important;
-}
-
-.overflow-y-hidden {
-  overflow-y: hidden !important;
-}
-
-.overflow-y-visible {
-  overflow-y: visible !important;
-}
-
-.overflow-y-scroll {
-  overflow-y: scroll !important;
-}
-
-.d-inline {
-  display: inline !important;
-}
-
-.d-inline-block {
-  display: inline-block !important;
-}
-
-.d-block {
-  display: block !important;
-}
-
-.d-grid {
-  display: grid !important;
-}
-
-.d-inline-grid {
-  display: inline-grid !important;
-}
-
-.d-table {
-  display: table !important;
-}
-
-.d-table-row {
-  display: table-row !important;
-}
-
-.d-table-cell {
-  display: table-cell !important;
-}
-
-.d-flex {
-  display: flex !important;
-}
-
-.d-inline-flex {
-  display: inline-flex !important;
-}
-
-.d-none {
-  display: none !important;
-}
-
-.shadow {
-  box-shadow: var(--bs-box-shadow) !important;
-}
-
-.shadow-sm {
-  box-shadow: var(--bs-box-shadow-sm) !important;
-}
-
-.shadow-lg {
-  box-shadow: var(--bs-box-shadow-lg) !important;
-}
-
-.shadow-none {
-  box-shadow: none !important;
-}
-
-.focus-ring-primary {
-  --bs-focus-ring-color: rgba(var(--bs-primary-rgb), var(--bs-focus-ring-opacity));
-}
-
-.focus-ring-secondary {
-  --bs-focus-ring-color: rgba(var(--bs-secondary-rgb), var(--bs-focus-ring-opacity));
-}
-
-.focus-ring-success {
-  --bs-focus-ring-color: rgba(var(--bs-success-rgb), var(--bs-focus-ring-opacity));
-}
-
-.focus-ring-info {
-  --bs-focus-ring-color: rgba(var(--bs-info-rgb), var(--bs-focus-ring-opacity));
-}
-
-.focus-ring-warning {
-  --bs-focus-ring-color: rgba(var(--bs-warning-rgb), var(--bs-focus-ring-opacity));
-}
-
-.focus-ring-danger {
-  --bs-focus-ring-color: rgba(var(--bs-danger-rgb), var(--bs-focus-ring-opacity));
-}
-
-.focus-ring-light {
-  --bs-focus-ring-color: rgba(var(--bs-light-rgb), var(--bs-focus-ring-opacity));
-}
-
-.focus-ring-dark {
-  --bs-focus-ring-color: rgba(var(--bs-dark-rgb), var(--bs-focus-ring-opacity));
-}
-
-.position-static {
-  position: static !important;
-}
-
-.position-relative {
-  position: relative !important;
-}
-
-.position-absolute {
-  position: absolute !important;
-}
-
-.position-fixed {
-  position: fixed !important;
-}
-
-.position-sticky {
-  position: sticky !important;
-}
-
-.top-0 {
-  top: 0 !important;
-}
-
-.top-50 {
-  top: 50% !important;
-}
-
-.top-100 {
-  top: 100% !important;
-}
-
-.bottom-0 {
-  bottom: 0 !important;
-}
-
-.bottom-50 {
-  bottom: 50% !important;
-}
-
-.bottom-100 {
-  bottom: 100% !important;
-}
-
-.start-0 {
-  left: 0 !important;
-}
-
-.start-50 {
-  left: 50% !important;
-}
-
-.start-100 {
-  left: 100% !important;
-}
-
-.end-0 {
-  right: 0 !important;
-}
-
-.end-50 {
-  right: 50% !important;
-}
-
-.end-100 {
-  right: 100% !important;
-}
-
-.translate-middle {
-  transform: translate(-50%, -50%) !important;
-}
-
-.translate-middle-x {
-  transform: translateX(-50%) !important;
-}
-
-.translate-middle-y {
-  transform: translateY(-50%) !important;
-}
-
-.border {
-  border: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color) !important;
-}
-
-.border-0 {
-  border: 0 !important;
-}
-
-.border-top {
-  border-top: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color) !important;
-}
-
-.border-top-0 {
-  border-top: 0 !important;
-}
-
-.border-end {
-  border-right: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color) !important;
-}
-
-.border-end-0 {
-  border-right: 0 !important;
-}
-
-.border-bottom {
-  border-bottom: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color) !important;
-}
-
-.border-bottom-0 {
-  border-bottom: 0 !important;
-}
-
-.border-start {
-  border-left: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color) !important;
-}
-
-.border-start-0 {
-  border-left: 0 !important;
-}
-
-.border-primary {
-  --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-primary-rgb), var(--bs-border-opacity)) !important;
-}
-
-.border-secondary {
-  --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-secondary-rgb), var(--bs-border-opacity)) !important;
-}
-
-.border-success {
-  --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-success-rgb), var(--bs-border-opacity)) !important;
-}
-
-.border-info {
-  --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-info-rgb), var(--bs-border-opacity)) !important;
-}
-
-.border-warning {
-  --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-warning-rgb), var(--bs-border-opacity)) !important;
-}
-
-.border-danger {
-  --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-danger-rgb), var(--bs-border-opacity)) !important;
-}
-
-.border-light {
-  --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-light-rgb), var(--bs-border-opacity)) !important;
-}
-
-.border-dark {
-  --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-dark-rgb), var(--bs-border-opacity)) !important;
-}
-
-.border-black {
-  --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-black-rgb), var(--bs-border-opacity)) !important;
-}
-
-.border-white {
-  --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-white-rgb), var(--bs-border-opacity)) !important;
-}
-
-.border-primary-subtle {
-  border-color: var(--bs-primary-border-subtle) !important;
-}
-
-.border-secondary-subtle {
-  border-color: var(--bs-secondary-border-subtle) !important;
-}
-
-.border-success-subtle {
-  border-color: var(--bs-success-border-subtle) !important;
-}
-
-.border-info-subtle {
-  border-color: var(--bs-info-border-subtle) !important;
-}
-
-.border-warning-subtle {
-  border-color: var(--bs-warning-border-subtle) !important;
-}
-
-.border-danger-subtle {
-  border-color: var(--bs-danger-border-subtle) !important;
-}
-
-.border-light-subtle {
-  border-color: var(--bs-light-border-subtle) !important;
-}
-
-.border-dark-subtle {
-  border-color: var(--bs-dark-border-subtle) !important;
-}
-
-.border-1 {
-  border-width: 1px !important;
-}
-
-.border-2 {
-  border-width: 2px !important;
-}
-
-.border-3 {
-  border-width: 3px !important;
-}
-
-.border-4 {
-  border-width: 4px !important;
-}
-
-.border-5 {
-  border-width: 5px !important;
-}
-
-.border-opacity-10 {
-  --bs-border-opacity: 0.1;
-}
-
-.border-opacity-25 {
-  --bs-border-opacity: 0.25;
-}
-
-.border-opacity-50 {
-  --bs-border-opacity: 0.5;
-}
-
-.border-opacity-75 {
-  --bs-border-opacity: 0.75;
-}
-
-.border-opacity-100 {
-  --bs-border-opacity: 1;
-}
-
-.w-25 {
-  width: 25% !important;
-}
-
-.w-50 {
-  width: 50% !important;
-}
-
-.w-75 {
-  width: 75% !important;
-}
-
-.w-100 {
-  width: 100% !important;
-}
-
-.w-auto {
-  width: auto !important;
-}
-
-.mw-100 {
-  max-width: 100% !important;
-}
-
-.vw-100 {
-  width: 100vw !important;
-}
-
-.min-vw-100 {
-  min-width: 100vw !important;
-}
-
-.h-25 {
-  height: 25% !important;
-}
-
-.h-50 {
-  height: 50% !important;
-}
-
-.h-75 {
-  height: 75% !important;
-}
-
-.h-100 {
-  height: 100% !important;
-}
-
-.h-auto {
-  height: auto !important;
-}
-
-.mh-100 {
-  max-height: 100% !important;
-}
-
-.vh-100 {
-  height: 100vh !important;
-}
-
-.min-vh-100 {
-  min-height: 100vh !important;
-}
-
-.flex-fill {
-  flex: 1 1 auto !important;
-}
-
-.flex-row {
-  flex-direction: row !important;
-}
-
-.flex-column {
-  flex-direction: column !important;
-}
-
-.flex-row-reverse {
-  flex-direction: row-reverse !important;
-}
-
-.flex-column-reverse {
-  flex-direction: column-reverse !important;
-}
-
-.flex-grow-0 {
-  flex-grow: 0 !important;
-}
-
-.flex-grow-1 {
-  flex-grow: 1 !important;
-}
-
-.flex-shrink-0 {
-  flex-shrink: 0 !important;
-}
-
-.flex-shrink-1 {
-  flex-shrink: 1 !important;
-}
-
-.flex-wrap {
-  flex-wrap: wrap !important;
-}
-
-.flex-nowrap {
-  flex-wrap: nowrap !important;
-}
-
-.flex-wrap-reverse {
-  flex-wrap: wrap-reverse !important;
-}
-
-.justify-content-start {
-  justify-content: flex-start !important;
-}
-
-.justify-content-end {
-  justify-content: flex-end !important;
-}
-
-.justify-content-center {
-  justify-content: center !important;
-}
-
-.justify-content-between {
-  justify-content: space-between !important;
-}
-
-.justify-content-around {
-  justify-content: space-around !important;
-}
-
-.justify-content-evenly {
-  justify-content: space-evenly !important;
-}
-
-.align-items-start {
-  align-items: flex-start !important;
-}
-
-.align-items-end {
-  align-items: flex-end !important;
-}
-
-.align-items-center {
-  align-items: center !important;
-}
-
-.align-items-baseline {
-  align-items: baseline !important;
-}
-
-.align-items-stretch {
-  align-items: stretch !important;
-}
-
-.align-content-start {
-  align-content: flex-start !important;
-}
 
-.align-content-end {
-  align-content: flex-end !important;
-}
-
-.align-content-center {
-  align-content: center !important;
-}
-
-.align-content-between {
-  align-content: space-between !important;
-}
-
-.align-content-around {
-  align-content: space-around !important;
-}
-
-.align-content-stretch {
-  align-content: stretch !important;
-}
-
-.align-self-auto {
-  align-self: auto !important;
-}
-
-.align-self-start {
-  align-self: flex-start !important;
-}
-
-.align-self-end {
-  align-self: flex-end !important;
-}
-
-.align-self-center {
-  align-self: center !important;
-}
-
-.align-self-baseline {
-  align-self: baseline !important;
-}
-
-.align-self-stretch {
-  align-self: stretch !important;
-}
-
-.order-first {
-  order: -1 !important;
-}
-
-.order-0 {
-  order: 0 !important;
-}
-
-.order-1 {
-  order: 1 !important;
-}
-
-.order-2 {
-  order: 2 !important;
-}
-
-.order-3 {
-  order: 3 !important;
-}
-
-.order-4 {
-  order: 4 !important;
-}
-
-.order-5 {
-  order: 5 !important;
-}
-
-.order-last {
-  order: 6 !important;
-}
-
-.m-0 {
-  margin: 0 !important;
-}
-
-.m-1 {
-  margin: 0.25rem !important;
-}
-
-.m-2 {
-  margin: 0.5rem !important;
-}
-
-.m-3 {
-  margin: 1rem !important;
-}
-
-.m-4 {
-  margin: 1.5rem !important;
-}
-
-.m-5 {
-  margin: 3rem !important;
-}
-
-.m-auto {
-  margin: auto !important;
-}
-
-.mx-0 {
-  margin-right: 0 !important;
-  margin-left: 0 !important;
-}
-
-.mx-1 {
-  margin-right: 0.25rem !important;
-  margin-left: 0.25rem !important;
-}
-
-.mx-2 {
-  margin-right: 0.5rem !important;
-  margin-left: 0.5rem !important;
-}
-
-.mx-3 {
-  margin-right: 1rem !important;
-  margin-left: 1rem !important;
-}
-
-.mx-4 {
-  margin-right: 1.5rem !important;
-  margin-left: 1.5rem !important;
-}
-
-.mx-5 {
-  margin-right: 3rem !important;
-  margin-left: 3rem !important;
-}
-
-.mx-auto {
-  margin-right: auto !important;
-  margin-left: auto !important;
-}
-
-.my-0 {
-  margin-top: 0 !important;
-  margin-bottom: 0 !important;
-}
-
-.my-1 {
-  margin-top: 0.25rem !important;
-  margin-bottom: 0.25rem !important;
-}
-
-.my-2 {
-  margin-top: 0.5rem !important;
-  margin-bottom: 0.5rem !important;
-}
-
-.my-3 {
-  margin-top: 1rem !important;
-  margin-bottom: 1rem !important;
-}
-
-.my-4 {
-  margin-top: 1.5rem !important;
-  margin-bottom: 1.5rem !important;
-}
-
-.my-5 {
-  margin-top: 3rem !important;
-  margin-bottom: 3rem !important;
-}
-
-.my-auto {
-  margin-top: auto !important;
-  margin-bottom: auto !important;
-}
-
-.mt-0 {
-  margin-top: 0 !important;
-}
-
-.mt-1 {
-  margin-top: 0.25rem !important;
-}
-
-.mt-2 {
-  margin-top: 0.5rem !important;
-}
-
-.mt-3 {
-  margin-top: 1rem !important;
-}
-
-.mt-4 {
-  margin-top: 1.5rem !important;
-}
-
-.mt-5 {
-  margin-top: 3rem !important;
-}
-
-.mt-auto {
-  margin-top: auto !important;
-}
-
-.me-0 {
-  margin-right: 0 !important;
-}
-
-.me-1 {
-  margin-right: 0.25rem !important;
-}
-
-.me-2 {
-  margin-right: 0.5rem !important;
-}
-
-.me-3 {
-  margin-right: 1rem !important;
-}
-
-.me-4 {
-  margin-right: 1.5rem !important;
-}
-
-.me-5 {
-  margin-right: 3rem !important;
-}
-
-.me-auto {
-  margin-right: auto !important;
-}
-
-.mb-0 {
-  margin-bottom: 0 !important;
-}
-
-.mb-1 {
-  margin-bottom: 0.25rem !important;
-}
-
-.mb-2 {
-  margin-bottom: 0.5rem !important;
-}
-
-.mb-3 {
-  margin-bottom: 1rem !important;
-}
-
-.mb-4 {
-  margin-bottom: 1.5rem !important;
-}
-
-.mb-5 {
-  margin-bottom: 3rem !important;
-}
-
-.mb-auto {
-  margin-bottom: auto !important;
-}
-
-.ms-0 {
-  margin-left: 0 !important;
-}
-
-.ms-1 {
-  margin-left: 0.25rem !important;
-}
-
-.ms-2 {
-  margin-left: 0.5rem !important;
-}
-
-.ms-3 {
-  margin-left: 1rem !important;
-}
-
-.ms-4 {
-  margin-left: 1.5rem !important;
-}
-
-.ms-5 {
-  margin-left: 3rem !important;
-}
-
-.ms-auto {
-  margin-left: auto !important;
-}
-
-.p-0 {
-  padding: 0 !important;
-}
-
-.p-1 {
-  padding: 0.25rem !important;
-}
-
-.p-2 {
-  padding: 0.5rem !important;
-}
-
-.p-3 {
-  padding: 1rem !important;
-}
-
-.p-4 {
-  padding: 1.5rem !important;
-}
-
-.p-5 {
-  padding: 3rem !important;
-}
-
-.px-0 {
-  padding-right: 0 !important;
-  padding-left: 0 !important;
-}
-
-.px-1 {
-  padding-right: 0.25rem !important;
-  padding-left: 0.25rem !important;
-}
-
-.px-2 {
-  padding-right: 0.5rem !important;
-  padding-left: 0.5rem !important;
-}
-
-.px-3 {
-  padding-right: 1rem !important;
-  padding-left: 1rem !important;
-}
-
-.px-4 {
-  padding-right: 1.5rem !important;
-  padding-left: 1.5rem !important;
-}
-
-.px-5 {
-  padding-right: 3rem !important;
-  padding-left: 3rem !important;
-}
-
-.py-0 {
-  padding-top: 0 !important;
-  padding-bottom: 0 !important;
-}
-
-.py-1 {
-  padding-top: 0.25rem !important;
-  padding-bottom: 0.25rem !important;
-}
-
-.py-2 {
-  padding-top: 0.5rem !important;
-  padding-bottom: 0.5rem !important;
-}
-
-.py-3 {
-  padding-top: 1rem !important;
-  padding-bottom: 1rem !important;
-}
-
-.py-4 {
-  padding-top: 1.5rem !important;
-  padding-bottom: 1.5rem !important;
-}
-
-.py-5 {
-  padding-top: 3rem !important;
-  padding-bottom: 3rem !important;
-}
-
-.pt-0 {
-  padding-top: 0 !important;
-}
-
-.pt-1 {
-  padding-top: 0.25rem !important;
-}
-
-.pt-2 {
-  padding-top: 0.5rem !important;
-}
-
-.pt-3 {
-  padding-top: 1rem !important;
-}
-
-.pt-4 {
-  padding-top: 1.5rem !important;
-}
-
-.pt-5 {
-  padding-top: 3rem !important;
-}
-
-.pe-0 {
-  padding-right: 0 !important;
-}
-
-.pe-1 {
-  padding-right: 0.25rem !important;
-}
-
-.pe-2 {
-  padding-right: 0.5rem !important;
-}
-
-.pe-3 {
-  padding-right: 1rem !important;
-}
-
-.pe-4 {
-  padding-right: 1.5rem !important;
-}
-
-.pe-5 {
-  padding-right: 3rem !important;
-}
-
-.pb-0 {
-  padding-bottom: 0 !important;
-}
-
-.pb-1 {
-  padding-bottom: 0.25rem !important;
-}
-
-.pb-2 {
-  padding-bottom: 0.5rem !important;
-}
-
-.pb-3 {
-  padding-bottom: 1rem !important;
-}
-
-.pb-4 {
-  padding-bottom: 1.5rem !important;
-}
-
-.pb-5 {
-  padding-bottom: 3rem !important;
-}
-
-.ps-0 {
-  padding-left: 0 !important;
-}
-
-.ps-1 {
-  padding-left: 0.25rem !important;
-}
-
-.ps-2 {
-  padding-left: 0.5rem !important;
-}
-
-.ps-3 {
-  padding-left: 1rem !important;
-}
-
-.ps-4 {
-  padding-left: 1.5rem !important;
-}
-
-.ps-5 {
-  padding-left: 3rem !important;
-}
-
-.gap-0 {
-  gap: 0 !important;
-}
-
-.gap-1 {
-  gap: 0.25rem !important;
-}
-
-.gap-2 {
-  gap: 0.5rem !important;
-}
-
-.gap-3 {
-  gap: 1rem !important;
-}
-
-.gap-4 {
-  gap: 1.5rem !important;
-}
-
-.gap-5 {
-  gap: 3rem !important;
-}
-
-.row-gap-0 {
-  row-gap: 0 !important;
-}
-
-.row-gap-1 {
-  row-gap: 0.25rem !important;
-}
-
-.row-gap-2 {
-  row-gap: 0.5rem !important;
-}
-
-.row-gap-3 {
-  row-gap: 1rem !important;
-}
-
-.row-gap-4 {
-  row-gap: 1.5rem !important;
-}
-
-.row-gap-5 {
-  row-gap: 3rem !important;
-}
-
-.column-gap-0 {
-  -moz-column-gap: 0 !important;
-       column-gap: 0 !important;
-}
-
-.column-gap-1 {
-  -moz-column-gap: 0.25rem !important;
-       column-gap: 0.25rem !important;
-}
-
-.column-gap-2 {
-  -moz-column-gap: 0.5rem !important;
-       column-gap: 0.5rem !important;
-}
-
-.column-gap-3 {
-  -moz-column-gap: 1rem !important;
-       column-gap: 1rem !important;
-}
-
-.column-gap-4 {
-  -moz-column-gap: 1.5rem !important;
-       column-gap: 1.5rem !important;
-}
-
-.column-gap-5 {
-  -moz-column-gap: 3rem !important;
-       column-gap: 3rem !important;
-}
-
-.font-monospace {
-  font-family: var(--bs-font-monospace) !important;
-}
 
 .fs-1 {
-  font-size: calc(1.34375rem + 1.125vw) !important;
+    font-size: calc(1.34375rem + 1.125vw) !important;
 }
 
 .fs-2 {
-  font-size: calc(1.3rem + 0.6vw) !important;
+    font-size: calc(1.3rem + 0.6vw) !important;
 }
 
 .fs-3 {
-  font-size: calc(1.278125rem + 0.3375vw) !important;
+    font-size: calc(1.278125rem + 0.3375vw) !important;
 }
 
 .fs-4 {
-  font-size: calc(1.25625rem + 0.075vw) !important;
+    font-size: calc(1.25625rem + 0.075vw) !important;
 }
 
 .fs-5 {
-  font-size: 1.09375rem !important;
+    font-size: 1.09375rem !important;
 }
 
 .fs-6 {
-  font-size: 0.875rem !important;
+    font-size: 0.875rem !important;
 }
 
-.fst-italic {
-  font-style: italic !important;
+.text-muted,
+.demo-code-preview:before,
+.chat-block .chat-content .messages .message-item.message-item-divider span {
+    --bs-text-opacity: 1;
+    color: var(--bs-secondary-color) !important;
 }
 
-.fst-normal {
-  font-style: normal !important;
-}
-
-.fw-lighter {
-  font-weight: lighter !important;
-}
-
-.fw-light {
-  font-weight: 300 !important;
-}
-
-.fw-normal {
-  font-weight: 400 !important;
-}
-
-.fw-medium {
-  font-weight: 500 !important;
-}
-
-.fw-semibold {
-  font-weight: 600 !important;
-}
-
-.fw-bold {
-  font-weight: 700 !important;
-}
-
-.fw-bolder {
-  font-weight: bolder !important;
-}
-
-.lh-1 {
-  line-height: 1 !important;
-}
-
-.lh-sm {
-  line-height: 1.25 !important;
-}
-
-.lh-base {
-  line-height: 1.5 !important;
-}
-
-.lh-lg {
-  line-height: 2 !important;
-}
-
-.text-start {
-  text-align: left !important;
-}
-
-.text-end {
-  text-align: right !important;
-}
-
-.text-center {
-  text-align: center !important;
-}
-
-.text-decoration-none {
-  text-decoration: none !important;
-}
-
-.text-decoration-underline {
-  text-decoration: underline !important;
-}
-
-.text-decoration-line-through {
-  text-decoration: line-through !important;
-}
-
-.text-lowercase {
-  text-transform: lowercase !important;
-}
-
-.text-uppercase {
-  text-transform: uppercase !important;
-}
-
-.text-capitalize {
-  text-transform: capitalize !important;
-}
-
-.text-wrap {
-  white-space: normal !important;
-}
-
-.text-nowrap {
-  white-space: nowrap !important;
-}
-
-/* rtl:begin:remove */
-.text-break {
-  word-wrap: break-word !important;
-  word-break: break-word !important;
-}
-
-/* rtl:end:remove */
-.text-primary {
-  --bs-text-opacity: 1;
-  color: rgba(var(--bs-primary-rgb), var(--bs-text-opacity)) !important;
-}
-
-.text-secondary {
-  --bs-text-opacity: 1;
-  color: rgba(var(--bs-secondary-rgb), var(--bs-text-opacity)) !important;
-}
-
-.text-success {
-  --bs-text-opacity: 1;
-  color: rgba(var(--bs-success-rgb), var(--bs-text-opacity)) !important;
-}
-
-.text-info {
-  --bs-text-opacity: 1;
-  color: rgba(var(--bs-info-rgb), var(--bs-text-opacity)) !important;
-}
-
-.text-warning {
-  --bs-text-opacity: 1;
-  color: rgba(var(--bs-warning-rgb), var(--bs-text-opacity)) !important;
-}
-
-.text-danger {
-  --bs-text-opacity: 1;
-  color: rgba(var(--bs-danger-rgb), var(--bs-text-opacity)) !important;
-}
-
-.text-light {
-  --bs-text-opacity: 1;
-  color: rgba(var(--bs-light-rgb), var(--bs-text-opacity)) !important;
-}
-
-.text-dark {
-  --bs-text-opacity: 1;
-  color: rgba(var(--bs-dark-rgb), var(--bs-text-opacity)) !important;
-}
-
-.text-black {
-  --bs-text-opacity: 1;
-  color: rgba(var(--bs-black-rgb), var(--bs-text-opacity)) !important;
-}
-
-.text-white {
-  --bs-text-opacity: 1;
-  color: rgba(var(--bs-white-rgb), var(--bs-text-opacity)) !important;
-}
-
-.text-body {
-  --bs-text-opacity: 1;
-  color: rgba(var(--bs-body-color-rgb), var(--bs-text-opacity)) !important;
-}
-
-.text-muted, .demo-code-preview:before, .chat-block .chat-content .messages .message-item.message-item-divider span {
-  --bs-text-opacity: 1;
-  color: var(--bs-secondary-color) !important;
-}
-
-.text-black-50 {
-  --bs-text-opacity: 1;
-  color: rgba(0, 0, 0, 0.5) !important;
-}
-
-.text-white-50 {
-  --bs-text-opacity: 1;
-  color: rgba(255, 255, 255, 0.5) !important;
-}
-
-.text-body-secondary {
-  --bs-text-opacity: 1;
-  color: var(--bs-secondary-color) !important;
-}
-
-.text-body-tertiary {
-  --bs-text-opacity: 1;
-  color: var(--bs-tertiary-color) !important;
-}
-
-.text-body-emphasis {
-  --bs-text-opacity: 1;
-  color: var(--bs-emphasis-color) !important;
-}
-
-.text-reset {
-  --bs-text-opacity: 1;
-  color: inherit !important;
-}
-
-.text-opacity-25 {
-  --bs-text-opacity: 0.25;
-}
-
-.text-opacity-50 {
-  --bs-text-opacity: 0.5;
-}
-
-.text-opacity-75 {
-  --bs-text-opacity: 0.75;
-}
-
-.text-opacity-100 {
-  --bs-text-opacity: 1;
-}
-
-.text-primary-emphasis {
-  color: var(--bs-primary-text-emphasis) !important;
-}
-
-.text-secondary-emphasis {
-  color: var(--bs-secondary-text-emphasis) !important;
-}
-
-.text-success-emphasis {
-  color: var(--bs-success-text-emphasis) !important;
-}
-
-.text-info-emphasis {
-  color: var(--bs-info-text-emphasis) !important;
-}
-
-.text-warning-emphasis {
-  color: var(--bs-warning-text-emphasis) !important;
-}
-
-.text-danger-emphasis {
-  color: var(--bs-danger-text-emphasis) !important;
-}
-
-.text-light-emphasis {
-  color: var(--bs-light-text-emphasis) !important;
-}
-
-.text-dark-emphasis {
-  color: var(--bs-dark-text-emphasis) !important;
-}
-
-.link-opacity-10 {
-  --bs-link-opacity: 0.1;
-}
-
-.link-opacity-10-hover:hover {
-  --bs-link-opacity: 0.1;
-}
-
-.link-opacity-25 {
-  --bs-link-opacity: 0.25;
-}
-
-.link-opacity-25-hover:hover {
-  --bs-link-opacity: 0.25;
-}
-
-.link-opacity-50 {
-  --bs-link-opacity: 0.5;
-}
-
-.link-opacity-50-hover:hover {
-  --bs-link-opacity: 0.5;
-}
-
-.link-opacity-75 {
-  --bs-link-opacity: 0.75;
-}
-
-.link-opacity-75-hover:hover {
-  --bs-link-opacity: 0.75;
-}
-
-.link-opacity-100 {
-  --bs-link-opacity: 1;
-}
-
-.link-opacity-100-hover:hover {
-  --bs-link-opacity: 1;
-}
-
-.link-offset-1 {
-  text-underline-offset: 0.125em !important;
-}
-
-.link-offset-1-hover:hover {
-  text-underline-offset: 0.125em !important;
-}
-
-.link-offset-2 {
-  text-underline-offset: 0.25em !important;
-}
-
-.link-offset-2-hover:hover {
-  text-underline-offset: 0.25em !important;
-}
-
-.link-offset-3 {
-  text-underline-offset: 0.375em !important;
-}
-
-.link-offset-3-hover:hover {
-  text-underline-offset: 0.375em !important;
-}
-
-.link-underline-primary {
-  --bs-link-underline-opacity: 1;
-  text-decoration-color: rgba(var(--bs-primary-rgb), var(--bs-link-underline-opacity)) !important;
-}
-
-.link-underline-secondary {
-  --bs-link-underline-opacity: 1;
-  text-decoration-color: rgba(var(--bs-secondary-rgb), var(--bs-link-underline-opacity)) !important;
-}
-
-.link-underline-success {
-  --bs-link-underline-opacity: 1;
-  text-decoration-color: rgba(var(--bs-success-rgb), var(--bs-link-underline-opacity)) !important;
-}
-
-.link-underline-info {
-  --bs-link-underline-opacity: 1;
-  text-decoration-color: rgba(var(--bs-info-rgb), var(--bs-link-underline-opacity)) !important;
-}
-
-.link-underline-warning {
-  --bs-link-underline-opacity: 1;
-  text-decoration-color: rgba(var(--bs-warning-rgb), var(--bs-link-underline-opacity)) !important;
-}
-
-.link-underline-danger {
-  --bs-link-underline-opacity: 1;
-  text-decoration-color: rgba(var(--bs-danger-rgb), var(--bs-link-underline-opacity)) !important;
-}
-
-.link-underline-light {
-  --bs-link-underline-opacity: 1;
-  text-decoration-color: rgba(var(--bs-light-rgb), var(--bs-link-underline-opacity)) !important;
-}
-
-.link-underline-dark {
-  --bs-link-underline-opacity: 1;
-  text-decoration-color: rgba(var(--bs-dark-rgb), var(--bs-link-underline-opacity)) !important;
-}
-
-.link-underline {
-  --bs-link-underline-opacity: 1;
-  text-decoration-color: rgba(var(--bs-link-color-rgb), var(--bs-link-underline-opacity, 1)) !important;
-}
-
-.link-underline-opacity-0 {
-  --bs-link-underline-opacity: 0;
-}
-
-.link-underline-opacity-0-hover:hover {
-  --bs-link-underline-opacity: 0;
-}
-
-.link-underline-opacity-10 {
-  --bs-link-underline-opacity: 0.1;
-}
-
-.link-underline-opacity-10-hover:hover {
-  --bs-link-underline-opacity: 0.1;
-}
-
-.link-underline-opacity-25 {
-  --bs-link-underline-opacity: 0.25;
-}
-
-.link-underline-opacity-25-hover:hover {
-  --bs-link-underline-opacity: 0.25;
-}
-
-.link-underline-opacity-50 {
-  --bs-link-underline-opacity: 0.5;
-}
-
-.link-underline-opacity-50-hover:hover {
-  --bs-link-underline-opacity: 0.5;
-}
-
-.link-underline-opacity-75 {
-  --bs-link-underline-opacity: 0.75;
-}
-
-.link-underline-opacity-75-hover:hover {
-  --bs-link-underline-opacity: 0.75;
-}
-
-.link-underline-opacity-100 {
-  --bs-link-underline-opacity: 1;
-}
 
-.link-underline-opacity-100-hover:hover {
-  --bs-link-underline-opacity: 1;
-}
-
-.bg-primary {
-  --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-primary-rgb), var(--bs-bg-opacity)) !important;
-}
-
-.bg-secondary {
-  --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-secondary-rgb), var(--bs-bg-opacity)) !important;
-}
-
-.bg-success {
-  --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-success-rgb), var(--bs-bg-opacity)) !important;
-}
-
-.bg-info {
-  --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-info-rgb), var(--bs-bg-opacity)) !important;
-}
-
-.bg-warning {
-  --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-warning-rgb), var(--bs-bg-opacity)) !important;
-}
-
-.bg-danger {
-  --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-danger-rgb), var(--bs-bg-opacity)) !important;
-}
-
-.bg-light {
-  --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-light-rgb), var(--bs-bg-opacity)) !important;
-}
-
-.bg-dark {
-  --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-dark-rgb), var(--bs-bg-opacity)) !important;
-}
-
-.bg-black {
-  --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-black-rgb), var(--bs-bg-opacity)) !important;
-}
-
-.bg-white {
-  --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-white-rgb), var(--bs-bg-opacity)) !important;
-}
-
-.bg-body {
-  --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-body-bg-rgb), var(--bs-bg-opacity)) !important;
-}
-
-.bg-transparent {
-  --bs-bg-opacity: 1;
-  background-color: transparent !important;
-}
-
-.bg-body-secondary {
-  --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-secondary-bg-rgb), var(--bs-bg-opacity)) !important;
-}
-
-.bg-body-tertiary {
-  --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-tertiary-bg-rgb), var(--bs-bg-opacity)) !important;
-}
-
-.bg-opacity-10 {
-  --bs-bg-opacity: 0.1;
-}
-
-.bg-opacity-25 {
-  --bs-bg-opacity: 0.25;
-}
-
-.bg-opacity-50 {
-  --bs-bg-opacity: 0.5;
-}
-
-.bg-opacity-75 {
-  --bs-bg-opacity: 0.75;
-}
-
-.bg-opacity-100 {
-  --bs-bg-opacity: 1;
-}
-
-.bg-primary-subtle {
-  background-color: var(--bs-primary-bg-subtle) !important;
-}
-
-.bg-secondary-subtle {
-  background-color: var(--bs-secondary-bg-subtle) !important;
-}
-
-.bg-success-subtle {
-  background-color: var(--bs-success-bg-subtle) !important;
-}
-
-.bg-info-subtle {
-  background-color: var(--bs-info-bg-subtle) !important;
-}
-
-.bg-warning-subtle {
-  background-color: var(--bs-warning-bg-subtle) !important;
-}
-
-.bg-danger-subtle {
-  background-color: var(--bs-danger-bg-subtle) !important;
-}
-
-.bg-light-subtle {
-  background-color: var(--bs-light-bg-subtle) !important;
-}
-
-.bg-dark-subtle {
-  background-color: var(--bs-dark-bg-subtle) !important;
-}
-
-.bg-gradient {
-  background-image: var(--bs-gradient) !important;
-}
-
-.user-select-all {
-  -webkit-user-select: all !important;
-     -moz-user-select: all !important;
-          user-select: all !important;
-}
-
-.user-select-auto {
-  -webkit-user-select: auto !important;
-     -moz-user-select: auto !important;
-          user-select: auto !important;
-}
-
-.user-select-none {
-  -webkit-user-select: none !important;
-     -moz-user-select: none !important;
-          user-select: none !important;
-}
-
-.pe-none {
-  pointer-events: none !important;
-}
-
-.pe-auto {
-  pointer-events: auto !important;
-}
-
-.rounded {
-  border-radius: var(--bs-border-radius) !important;
-}
-
-.rounded-0 {
-  border-radius: 0 !important;
-}
-
-.rounded-1 {
-  border-radius: var(--bs-border-radius-sm) !important;
-}
-
-.rounded-2 {
-  border-radius: var(--bs-border-radius) !important;
-}
-
-.rounded-3 {
-  border-radius: var(--bs-border-radius-lg) !important;
-}
-
-.rounded-4 {
-  border-radius: var(--bs-border-radius-xl) !important;
-}
-
-.rounded-5 {
-  border-radius: var(--bs-border-radius-xxl) !important;
-}
-
-.rounded-circle {
-  border-radius: 50% !important;
-}
-
-.rounded-pill {
-  border-radius: var(--bs-border-radius-pill) !important;
-}
-
-.rounded-top {
-  border-top-left-radius: var(--bs-border-radius) !important;
-  border-top-right-radius: var(--bs-border-radius) !important;
-}
-
-.rounded-top-0 {
-  border-top-left-radius: 0 !important;
-  border-top-right-radius: 0 !important;
-}
-
-.rounded-top-1 {
-  border-top-left-radius: var(--bs-border-radius-sm) !important;
-  border-top-right-radius: var(--bs-border-radius-sm) !important;
-}
-
-.rounded-top-2 {
-  border-top-left-radius: var(--bs-border-radius) !important;
-  border-top-right-radius: var(--bs-border-radius) !important;
-}
-
-.rounded-top-3 {
-  border-top-left-radius: var(--bs-border-radius-lg) !important;
-  border-top-right-radius: var(--bs-border-radius-lg) !important;
-}
-
-.rounded-top-4 {
-  border-top-left-radius: var(--bs-border-radius-xl) !important;
-  border-top-right-radius: var(--bs-border-radius-xl) !important;
-}
-
-.rounded-top-5 {
-  border-top-left-radius: var(--bs-border-radius-xxl) !important;
-  border-top-right-radius: var(--bs-border-radius-xxl) !important;
-}
-
-.rounded-top-circle {
-  border-top-left-radius: 50% !important;
-  border-top-right-radius: 50% !important;
-}
-
-.rounded-top-pill {
-  border-top-left-radius: var(--bs-border-radius-pill) !important;
-  border-top-right-radius: var(--bs-border-radius-pill) !important;
-}
-
-.rounded-end {
-  border-top-right-radius: var(--bs-border-radius) !important;
-  border-bottom-right-radius: var(--bs-border-radius) !important;
-}
-
-.rounded-end-0 {
-  border-top-right-radius: 0 !important;
-  border-bottom-right-radius: 0 !important;
-}
-
-.rounded-end-1 {
-  border-top-right-radius: var(--bs-border-radius-sm) !important;
-  border-bottom-right-radius: var(--bs-border-radius-sm) !important;
-}
-
-.rounded-end-2 {
-  border-top-right-radius: var(--bs-border-radius) !important;
-  border-bottom-right-radius: var(--bs-border-radius) !important;
-}
-
-.rounded-end-3 {
-  border-top-right-radius: var(--bs-border-radius-lg) !important;
-  border-bottom-right-radius: var(--bs-border-radius-lg) !important;
-}
-
-.rounded-end-4 {
-  border-top-right-radius: var(--bs-border-radius-xl) !important;
-  border-bottom-right-radius: var(--bs-border-radius-xl) !important;
-}
-
-.rounded-end-5 {
-  border-top-right-radius: var(--bs-border-radius-xxl) !important;
-  border-bottom-right-radius: var(--bs-border-radius-xxl) !important;
-}
-
-.rounded-end-circle {
-  border-top-right-radius: 50% !important;
-  border-bottom-right-radius: 50% !important;
-}
-
-.rounded-end-pill {
-  border-top-right-radius: var(--bs-border-radius-pill) !important;
-  border-bottom-right-radius: var(--bs-border-radius-pill) !important;
-}
-
-.rounded-bottom {
-  border-bottom-right-radius: var(--bs-border-radius) !important;
-  border-bottom-left-radius: var(--bs-border-radius) !important;
-}
-
-.rounded-bottom-0 {
-  border-bottom-right-radius: 0 !important;
-  border-bottom-left-radius: 0 !important;
-}
-
-.rounded-bottom-1 {
-  border-bottom-right-radius: var(--bs-border-radius-sm) !important;
-  border-bottom-left-radius: var(--bs-border-radius-sm) !important;
-}
-
-.rounded-bottom-2 {
-  border-bottom-right-radius: var(--bs-border-radius) !important;
-  border-bottom-left-radius: var(--bs-border-radius) !important;
-}
-
-.rounded-bottom-3 {
-  border-bottom-right-radius: var(--bs-border-radius-lg) !important;
-  border-bottom-left-radius: var(--bs-border-radius-lg) !important;
-}
-
-.rounded-bottom-4 {
-  border-bottom-right-radius: var(--bs-border-radius-xl) !important;
-  border-bottom-left-radius: var(--bs-border-radius-xl) !important;
-}
-
-.rounded-bottom-5 {
-  border-bottom-right-radius: var(--bs-border-radius-xxl) !important;
-  border-bottom-left-radius: var(--bs-border-radius-xxl) !important;
-}
-
-.rounded-bottom-circle {
-  border-bottom-right-radius: 50% !important;
-  border-bottom-left-radius: 50% !important;
-}
-
-.rounded-bottom-pill {
-  border-bottom-right-radius: var(--bs-border-radius-pill) !important;
-  border-bottom-left-radius: var(--bs-border-radius-pill) !important;
-}
-
-.rounded-start {
-  border-bottom-left-radius: var(--bs-border-radius) !important;
-  border-top-left-radius: var(--bs-border-radius) !important;
-}
-
-.rounded-start-0 {
-  border-bottom-left-radius: 0 !important;
-  border-top-left-radius: 0 !important;
-}
-
-.rounded-start-1 {
-  border-bottom-left-radius: var(--bs-border-radius-sm) !important;
-  border-top-left-radius: var(--bs-border-radius-sm) !important;
-}
-
-.rounded-start-2 {
-  border-bottom-left-radius: var(--bs-border-radius) !important;
-  border-top-left-radius: var(--bs-border-radius) !important;
-}
-
-.rounded-start-3 {
-  border-bottom-left-radius: var(--bs-border-radius-lg) !important;
-  border-top-left-radius: var(--bs-border-radius-lg) !important;
-}
-
-.rounded-start-4 {
-  border-bottom-left-radius: var(--bs-border-radius-xl) !important;
-  border-top-left-radius: var(--bs-border-radius-xl) !important;
-}
-
-.rounded-start-5 {
-  border-bottom-left-radius: var(--bs-border-radius-xxl) !important;
-  border-top-left-radius: var(--bs-border-radius-xxl) !important;
-}
-
-.rounded-start-circle {
-  border-bottom-left-radius: 50% !important;
-  border-top-left-radius: 50% !important;
-}
-
-.rounded-start-pill {
-  border-bottom-left-radius: var(--bs-border-radius-pill) !important;
-  border-top-left-radius: var(--bs-border-radius-pill) !important;
-}
-
-.visible {
-  visibility: visible !important;
-}
-
-.invisible {
-  visibility: hidden !important;
-}
-
-.z-n1 {
-  z-index: -1 !important;
-}
-
-.z-0 {
-  z-index: 0 !important;
-}
-
-.z-1 {
-  z-index: 1 !important;
-}
-
-.z-2 {
-  z-index: 2 !important;
-}
-
-.z-3 {
-  z-index: 3 !important;
-}
-
-@media (min-width: 576px) {
-  .float-sm-start {
-    float: left !important;
-  }
-  .float-sm-end {
-    float: right !important;
-  }
-  .float-sm-none {
-    float: none !important;
-  }
-  .object-fit-sm-contain {
-    -o-object-fit: contain !important;
-       object-fit: contain !important;
-  }
-  .object-fit-sm-cover {
-    -o-object-fit: cover !important;
-       object-fit: cover !important;
-  }
-  .object-fit-sm-fill {
-    -o-object-fit: fill !important;
-       object-fit: fill !important;
-  }
-  .object-fit-sm-scale {
-    -o-object-fit: scale-down !important;
-       object-fit: scale-down !important;
-  }
-  .object-fit-sm-none {
-    -o-object-fit: none !important;
-       object-fit: none !important;
-  }
-  .d-sm-inline {
-    display: inline !important;
-  }
-  .d-sm-inline-block {
-    display: inline-block !important;
-  }
-  .d-sm-block {
-    display: block !important;
-  }
-  .d-sm-grid {
-    display: grid !important;
-  }
-  .d-sm-inline-grid {
-    display: inline-grid !important;
-  }
-  .d-sm-table {
-    display: table !important;
-  }
-  .d-sm-table-row {
-    display: table-row !important;
-  }
-  .d-sm-table-cell {
-    display: table-cell !important;
-  }
-  .d-sm-flex {
-    display: flex !important;
-  }
-  .d-sm-inline-flex {
-    display: inline-flex !important;
-  }
-  .d-sm-none {
-    display: none !important;
-  }
-  .flex-sm-fill {
-    flex: 1 1 auto !important;
-  }
-  .flex-sm-row {
-    flex-direction: row !important;
-  }
-  .flex-sm-column {
-    flex-direction: column !important;
-  }
-  .flex-sm-row-reverse {
-    flex-direction: row-reverse !important;
-  }
-  .flex-sm-column-reverse {
-    flex-direction: column-reverse !important;
-  }
-  .flex-sm-grow-0 {
-    flex-grow: 0 !important;
-  }
-  .flex-sm-grow-1 {
-    flex-grow: 1 !important;
-  }
-  .flex-sm-shrink-0 {
-    flex-shrink: 0 !important;
-  }
-  .flex-sm-shrink-1 {
-    flex-shrink: 1 !important;
-  }
-  .flex-sm-wrap {
-    flex-wrap: wrap !important;
-  }
-  .flex-sm-nowrap {
-    flex-wrap: nowrap !important;
-  }
-  .flex-sm-wrap-reverse {
-    flex-wrap: wrap-reverse !important;
-  }
-  .justify-content-sm-start {
-    justify-content: flex-start !important;
-  }
-  .justify-content-sm-end {
-    justify-content: flex-end !important;
-  }
-  .justify-content-sm-center {
-    justify-content: center !important;
-  }
-  .justify-content-sm-between {
-    justify-content: space-between !important;
-  }
-  .justify-content-sm-around {
-    justify-content: space-around !important;
-  }
-  .justify-content-sm-evenly {
-    justify-content: space-evenly !important;
-  }
-  .align-items-sm-start {
-    align-items: flex-start !important;
-  }
-  .align-items-sm-end {
-    align-items: flex-end !important;
-  }
-  .align-items-sm-center {
-    align-items: center !important;
-  }
-  .align-items-sm-baseline {
-    align-items: baseline !important;
-  }
-  .align-items-sm-stretch {
-    align-items: stretch !important;
-  }
-  .align-content-sm-start {
-    align-content: flex-start !important;
-  }
-  .align-content-sm-end {
-    align-content: flex-end !important;
-  }
-  .align-content-sm-center {
-    align-content: center !important;
-  }
-  .align-content-sm-between {
-    align-content: space-between !important;
-  }
-  .align-content-sm-around {
-    align-content: space-around !important;
-  }
-  .align-content-sm-stretch {
-    align-content: stretch !important;
-  }
-  .align-self-sm-auto {
-    align-self: auto !important;
-  }
-  .align-self-sm-start {
-    align-self: flex-start !important;
-  }
-  .align-self-sm-end {
-    align-self: flex-end !important;
-  }
-  .align-self-sm-center {
-    align-self: center !important;
-  }
-  .align-self-sm-baseline {
-    align-self: baseline !important;
-  }
-  .align-self-sm-stretch {
-    align-self: stretch !important;
-  }
-  .order-sm-first {
-    order: -1 !important;
-  }
-  .order-sm-0 {
-    order: 0 !important;
-  }
-  .order-sm-1 {
-    order: 1 !important;
-  }
-  .order-sm-2 {
-    order: 2 !important;
-  }
-  .order-sm-3 {
-    order: 3 !important;
-  }
-  .order-sm-4 {
-    order: 4 !important;
-  }
-  .order-sm-5 {
-    order: 5 !important;
-  }
-  .order-sm-last {
-    order: 6 !important;
-  }
-  .m-sm-0 {
-    margin: 0 !important;
-  }
-  .m-sm-1 {
-    margin: 0.25rem !important;
-  }
-  .m-sm-2 {
-    margin: 0.5rem !important;
-  }
-  .m-sm-3 {
-    margin: 1rem !important;
-  }
-  .m-sm-4 {
-    margin: 1.5rem !important;
-  }
-  .m-sm-5 {
-    margin: 3rem !important;
-  }
-  .m-sm-auto {
-    margin: auto !important;
-  }
-  .mx-sm-0 {
-    margin-right: 0 !important;
-    margin-left: 0 !important;
-  }
-  .mx-sm-1 {
-    margin-right: 0.25rem !important;
-    margin-left: 0.25rem !important;
-  }
-  .mx-sm-2 {
-    margin-right: 0.5rem !important;
-    margin-left: 0.5rem !important;
-  }
-  .mx-sm-3 {
-    margin-right: 1rem !important;
-    margin-left: 1rem !important;
-  }
-  .mx-sm-4 {
-    margin-right: 1.5rem !important;
-    margin-left: 1.5rem !important;
-  }
-  .mx-sm-5 {
-    margin-right: 3rem !important;
-    margin-left: 3rem !important;
-  }
-  .mx-sm-auto {
-    margin-right: auto !important;
-    margin-left: auto !important;
-  }
-  .my-sm-0 {
-    margin-top: 0 !important;
-    margin-bottom: 0 !important;
-  }
-  .my-sm-1 {
-    margin-top: 0.25rem !important;
-    margin-bottom: 0.25rem !important;
-  }
-  .my-sm-2 {
-    margin-top: 0.5rem !important;
-    margin-bottom: 0.5rem !important;
-  }
-  .my-sm-3 {
-    margin-top: 1rem !important;
-    margin-bottom: 1rem !important;
-  }
-  .my-sm-4 {
-    margin-top: 1.5rem !important;
-    margin-bottom: 1.5rem !important;
-  }
-  .my-sm-5 {
-    margin-top: 3rem !important;
-    margin-bottom: 3rem !important;
-  }
-  .my-sm-auto {
-    margin-top: auto !important;
-    margin-bottom: auto !important;
-  }
-  .mt-sm-0 {
-    margin-top: 0 !important;
-  }
-  .mt-sm-1 {
-    margin-top: 0.25rem !important;
-  }
-  .mt-sm-2 {
-    margin-top: 0.5rem !important;
-  }
-  .mt-sm-3 {
-    margin-top: 1rem !important;
-  }
-  .mt-sm-4 {
-    margin-top: 1.5rem !important;
-  }
-  .mt-sm-5 {
-    margin-top: 3rem !important;
-  }
-  .mt-sm-auto {
-    margin-top: auto !important;
-  }
-  .me-sm-0 {
-    margin-right: 0 !important;
-  }
-  .me-sm-1 {
-    margin-right: 0.25rem !important;
-  }
-  .me-sm-2 {
-    margin-right: 0.5rem !important;
-  }
-  .me-sm-3 {
-    margin-right: 1rem !important;
-  }
-  .me-sm-4 {
-    margin-right: 1.5rem !important;
-  }
-  .me-sm-5 {
-    margin-right: 3rem !important;
-  }
-  .me-sm-auto {
-    margin-right: auto !important;
-  }
-  .mb-sm-0 {
-    margin-bottom: 0 !important;
-  }
-  .mb-sm-1 {
-    margin-bottom: 0.25rem !important;
-  }
-  .mb-sm-2 {
-    margin-bottom: 0.5rem !important;
-  }
-  .mb-sm-3 {
-    margin-bottom: 1rem !important;
-  }
-  .mb-sm-4 {
-    margin-bottom: 1.5rem !important;
-  }
-  .mb-sm-5 {
-    margin-bottom: 3rem !important;
-  }
-  .mb-sm-auto {
-    margin-bottom: auto !important;
-  }
-  .ms-sm-0 {
-    margin-left: 0 !important;
-  }
-  .ms-sm-1 {
-    margin-left: 0.25rem !important;
-  }
-  .ms-sm-2 {
-    margin-left: 0.5rem !important;
-  }
-  .ms-sm-3 {
-    margin-left: 1rem !important;
-  }
-  .ms-sm-4 {
-    margin-left: 1.5rem !important;
-  }
-  .ms-sm-5 {
-    margin-left: 3rem !important;
-  }
-  .ms-sm-auto {
-    margin-left: auto !important;
-  }
-  .p-sm-0 {
-    padding: 0 !important;
-  }
-  .p-sm-1 {
-    padding: 0.25rem !important;
-  }
-  .p-sm-2 {
-    padding: 0.5rem !important;
-  }
-  .p-sm-3 {
-    padding: 1rem !important;
-  }
-  .p-sm-4 {
-    padding: 1.5rem !important;
-  }
-  .p-sm-5 {
-    padding: 3rem !important;
-  }
-  .px-sm-0 {
-    padding-right: 0 !important;
-    padding-left: 0 !important;
-  }
-  .px-sm-1 {
-    padding-right: 0.25rem !important;
-    padding-left: 0.25rem !important;
-  }
-  .px-sm-2 {
-    padding-right: 0.5rem !important;
-    padding-left: 0.5rem !important;
-  }
-  .px-sm-3 {
-    padding-right: 1rem !important;
-    padding-left: 1rem !important;
-  }
-  .px-sm-4 {
-    padding-right: 1.5rem !important;
-    padding-left: 1.5rem !important;
-  }
-  .px-sm-5 {
-    padding-right: 3rem !important;
-    padding-left: 3rem !important;
-  }
-  .py-sm-0 {
-    padding-top: 0 !important;
-    padding-bottom: 0 !important;
-  }
-  .py-sm-1 {
-    padding-top: 0.25rem !important;
-    padding-bottom: 0.25rem !important;
-  }
-  .py-sm-2 {
-    padding-top: 0.5rem !important;
-    padding-bottom: 0.5rem !important;
-  }
-  .py-sm-3 {
-    padding-top: 1rem !important;
-    padding-bottom: 1rem !important;
-  }
-  .py-sm-4 {
-    padding-top: 1.5rem !important;
-    padding-bottom: 1.5rem !important;
-  }
-  .py-sm-5 {
-    padding-top: 3rem !important;
-    padding-bottom: 3rem !important;
-  }
-  .pt-sm-0 {
-    padding-top: 0 !important;
-  }
-  .pt-sm-1 {
-    padding-top: 0.25rem !important;
-  }
-  .pt-sm-2 {
-    padding-top: 0.5rem !important;
-  }
-  .pt-sm-3 {
-    padding-top: 1rem !important;
-  }
-  .pt-sm-4 {
-    padding-top: 1.5rem !important;
-  }
-  .pt-sm-5 {
-    padding-top: 3rem !important;
-  }
-  .pe-sm-0 {
-    padding-right: 0 !important;
-  }
-  .pe-sm-1 {
-    padding-right: 0.25rem !important;
-  }
-  .pe-sm-2 {
-    padding-right: 0.5rem !important;
-  }
-  .pe-sm-3 {
-    padding-right: 1rem !important;
-  }
-  .pe-sm-4 {
-    padding-right: 1.5rem !important;
-  }
-  .pe-sm-5 {
-    padding-right: 3rem !important;
-  }
-  .pb-sm-0 {
-    padding-bottom: 0 !important;
-  }
-  .pb-sm-1 {
-    padding-bottom: 0.25rem !important;
-  }
-  .pb-sm-2 {
-    padding-bottom: 0.5rem !important;
-  }
-  .pb-sm-3 {
-    padding-bottom: 1rem !important;
-  }
-  .pb-sm-4 {
-    padding-bottom: 1.5rem !important;
-  }
-  .pb-sm-5 {
-    padding-bottom: 3rem !important;
-  }
-  .ps-sm-0 {
-    padding-left: 0 !important;
-  }
-  .ps-sm-1 {
-    padding-left: 0.25rem !important;
-  }
-  .ps-sm-2 {
-    padding-left: 0.5rem !important;
-  }
-  .ps-sm-3 {
-    padding-left: 1rem !important;
-  }
-  .ps-sm-4 {
-    padding-left: 1.5rem !important;
-  }
-  .ps-sm-5 {
-    padding-left: 3rem !important;
-  }
-  .gap-sm-0 {
-    gap: 0 !important;
-  }
-  .gap-sm-1 {
-    gap: 0.25rem !important;
-  }
-  .gap-sm-2 {
-    gap: 0.5rem !important;
-  }
-  .gap-sm-3 {
-    gap: 1rem !important;
-  }
-  .gap-sm-4 {
-    gap: 1.5rem !important;
-  }
-  .gap-sm-5 {
-    gap: 3rem !important;
-  }
-  .row-gap-sm-0 {
-    row-gap: 0 !important;
-  }
-  .row-gap-sm-1 {
-    row-gap: 0.25rem !important;
-  }
-  .row-gap-sm-2 {
-    row-gap: 0.5rem !important;
-  }
-  .row-gap-sm-3 {
-    row-gap: 1rem !important;
-  }
-  .row-gap-sm-4 {
-    row-gap: 1.5rem !important;
-  }
-  .row-gap-sm-5 {
-    row-gap: 3rem !important;
-  }
-  .column-gap-sm-0 {
-    -moz-column-gap: 0 !important;
-         column-gap: 0 !important;
-  }
-  .column-gap-sm-1 {
-    -moz-column-gap: 0.25rem !important;
-         column-gap: 0.25rem !important;
-  }
-  .column-gap-sm-2 {
-    -moz-column-gap: 0.5rem !important;
-         column-gap: 0.5rem !important;
-  }
-  .column-gap-sm-3 {
-    -moz-column-gap: 1rem !important;
-         column-gap: 1rem !important;
-  }
-  .column-gap-sm-4 {
-    -moz-column-gap: 1.5rem !important;
-         column-gap: 1.5rem !important;
-  }
-  .column-gap-sm-5 {
-    -moz-column-gap: 3rem !important;
-         column-gap: 3rem !important;
-  }
-  .text-sm-start {
-    text-align: left !important;
-  }
-  .text-sm-end {
-    text-align: right !important;
-  }
-  .text-sm-center {
-    text-align: center !important;
-  }
-}
-@media (min-width: 768px) {
-  .float-md-start {
-    float: left !important;
-  }
-  .float-md-end {
-    float: right !important;
-  }
-  .float-md-none {
-    float: none !important;
-  }
-  .object-fit-md-contain {
-    -o-object-fit: contain !important;
-       object-fit: contain !important;
-  }
-  .object-fit-md-cover {
-    -o-object-fit: cover !important;
-       object-fit: cover !important;
-  }
-  .object-fit-md-fill {
-    -o-object-fit: fill !important;
-       object-fit: fill !important;
-  }
-  .object-fit-md-scale {
-    -o-object-fit: scale-down !important;
-       object-fit: scale-down !important;
-  }
-  .object-fit-md-none {
-    -o-object-fit: none !important;
-       object-fit: none !important;
-  }
-  .d-md-inline {
-    display: inline !important;
-  }
-  .d-md-inline-block {
-    display: inline-block !important;
-  }
-  .d-md-block {
-    display: block !important;
-  }
-  .d-md-grid {
-    display: grid !important;
-  }
-  .d-md-inline-grid {
-    display: inline-grid !important;
-  }
-  .d-md-table {
-    display: table !important;
-  }
-  .d-md-table-row {
-    display: table-row !important;
-  }
-  .d-md-table-cell {
-    display: table-cell !important;
-  }
-  .d-md-flex {
-    display: flex !important;
-  }
-  .d-md-inline-flex {
-    display: inline-flex !important;
-  }
-  .d-md-none {
-    display: none !important;
-  }
-  .flex-md-fill {
-    flex: 1 1 auto !important;
-  }
-  .flex-md-row {
-    flex-direction: row !important;
-  }
-  .flex-md-column {
-    flex-direction: column !important;
-  }
-  .flex-md-row-reverse {
-    flex-direction: row-reverse !important;
-  }
-  .flex-md-column-reverse {
-    flex-direction: column-reverse !important;
-  }
-  .flex-md-grow-0 {
-    flex-grow: 0 !important;
-  }
-  .flex-md-grow-1 {
-    flex-grow: 1 !important;
-  }
-  .flex-md-shrink-0 {
-    flex-shrink: 0 !important;
-  }
-  .flex-md-shrink-1 {
-    flex-shrink: 1 !important;
-  }
-  .flex-md-wrap {
-    flex-wrap: wrap !important;
-  }
-  .flex-md-nowrap {
-    flex-wrap: nowrap !important;
-  }
-  .flex-md-wrap-reverse {
-    flex-wrap: wrap-reverse !important;
-  }
-  .justify-content-md-start {
-    justify-content: flex-start !important;
-  }
-  .justify-content-md-end {
-    justify-content: flex-end !important;
-  }
-  .justify-content-md-center {
-    justify-content: center !important;
-  }
-  .justify-content-md-between {
-    justify-content: space-between !important;
-  }
-  .justify-content-md-around {
-    justify-content: space-around !important;
-  }
-  .justify-content-md-evenly {
-    justify-content: space-evenly !important;
-  }
-  .align-items-md-start {
-    align-items: flex-start !important;
-  }
-  .align-items-md-end {
-    align-items: flex-end !important;
-  }
-  .align-items-md-center {
-    align-items: center !important;
-  }
-  .align-items-md-baseline {
-    align-items: baseline !important;
-  }
-  .align-items-md-stretch {
-    align-items: stretch !important;
-  }
-  .align-content-md-start {
-    align-content: flex-start !important;
-  }
-  .align-content-md-end {
-    align-content: flex-end !important;
-  }
-  .align-content-md-center {
-    align-content: center !important;
-  }
-  .align-content-md-between {
-    align-content: space-between !important;
-  }
-  .align-content-md-around {
-    align-content: space-around !important;
-  }
-  .align-content-md-stretch {
-    align-content: stretch !important;
-  }
-  .align-self-md-auto {
-    align-self: auto !important;
-  }
-  .align-self-md-start {
-    align-self: flex-start !important;
-  }
-  .align-self-md-end {
-    align-self: flex-end !important;
-  }
-  .align-self-md-center {
-    align-self: center !important;
-  }
-  .align-self-md-baseline {
-    align-self: baseline !important;
-  }
-  .align-self-md-stretch {
-    align-self: stretch !important;
-  }
-  .order-md-first {
-    order: -1 !important;
-  }
-  .order-md-0 {
-    order: 0 !important;
-  }
-  .order-md-1 {
-    order: 1 !important;
-  }
-  .order-md-2 {
-    order: 2 !important;
-  }
-  .order-md-3 {
-    order: 3 !important;
-  }
-  .order-md-4 {
-    order: 4 !important;
-  }
-  .order-md-5 {
-    order: 5 !important;
-  }
-  .order-md-last {
-    order: 6 !important;
-  }
-  .m-md-0 {
-    margin: 0 !important;
-  }
-  .m-md-1 {
-    margin: 0.25rem !important;
-  }
-  .m-md-2 {
-    margin: 0.5rem !important;
-  }
-  .m-md-3 {
-    margin: 1rem !important;
-  }
-  .m-md-4 {
-    margin: 1.5rem !important;
-  }
-  .m-md-5 {
-    margin: 3rem !important;
-  }
-  .m-md-auto {
-    margin: auto !important;
-  }
-  .mx-md-0 {
-    margin-right: 0 !important;
-    margin-left: 0 !important;
-  }
-  .mx-md-1 {
-    margin-right: 0.25rem !important;
-    margin-left: 0.25rem !important;
-  }
-  .mx-md-2 {
-    margin-right: 0.5rem !important;
-    margin-left: 0.5rem !important;
-  }
-  .mx-md-3 {
-    margin-right: 1rem !important;
-    margin-left: 1rem !important;
-  }
-  .mx-md-4 {
-    margin-right: 1.5rem !important;
-    margin-left: 1.5rem !important;
-  }
-  .mx-md-5 {
-    margin-right: 3rem !important;
-    margin-left: 3rem !important;
-  }
-  .mx-md-auto {
-    margin-right: auto !important;
-    margin-left: auto !important;
-  }
-  .my-md-0 {
-    margin-top: 0 !important;
-    margin-bottom: 0 !important;
-  }
-  .my-md-1 {
-    margin-top: 0.25rem !important;
-    margin-bottom: 0.25rem !important;
-  }
-  .my-md-2 {
-    margin-top: 0.5rem !important;
-    margin-bottom: 0.5rem !important;
-  }
-  .my-md-3 {
-    margin-top: 1rem !important;
-    margin-bottom: 1rem !important;
-  }
-  .my-md-4 {
-    margin-top: 1.5rem !important;
-    margin-bottom: 1.5rem !important;
-  }
-  .my-md-5 {
-    margin-top: 3rem !important;
-    margin-bottom: 3rem !important;
-  }
-  .my-md-auto {
-    margin-top: auto !important;
-    margin-bottom: auto !important;
-  }
-  .mt-md-0 {
-    margin-top: 0 !important;
-  }
-  .mt-md-1 {
-    margin-top: 0.25rem !important;
-  }
-  .mt-md-2 {
-    margin-top: 0.5rem !important;
-  }
-  .mt-md-3 {
-    margin-top: 1rem !important;
-  }
-  .mt-md-4 {
-    margin-top: 1.5rem !important;
-  }
-  .mt-md-5 {
-    margin-top: 3rem !important;
-  }
-  .mt-md-auto {
-    margin-top: auto !important;
-  }
-  .me-md-0 {
-    margin-right: 0 !important;
-  }
-  .me-md-1 {
-    margin-right: 0.25rem !important;
-  }
-  .me-md-2 {
-    margin-right: 0.5rem !important;
-  }
-  .me-md-3 {
-    margin-right: 1rem !important;
-  }
-  .me-md-4 {
-    margin-right: 1.5rem !important;
-  }
-  .me-md-5 {
-    margin-right: 3rem !important;
-  }
-  .me-md-auto {
-    margin-right: auto !important;
-  }
-  .mb-md-0 {
-    margin-bottom: 0 !important;
-  }
-  .mb-md-1 {
-    margin-bottom: 0.25rem !important;
-  }
-  .mb-md-2 {
-    margin-bottom: 0.5rem !important;
-  }
-  .mb-md-3 {
-    margin-bottom: 1rem !important;
-  }
-  .mb-md-4 {
-    margin-bottom: 1.5rem !important;
-  }
-  .mb-md-5 {
-    margin-bottom: 3rem !important;
-  }
-  .mb-md-auto {
-    margin-bottom: auto !important;
-  }
-  .ms-md-0 {
-    margin-left: 0 !important;
-  }
-  .ms-md-1 {
-    margin-left: 0.25rem !important;
-  }
-  .ms-md-2 {
-    margin-left: 0.5rem !important;
-  }
-  .ms-md-3 {
-    margin-left: 1rem !important;
-  }
-  .ms-md-4 {
-    margin-left: 1.5rem !important;
-  }
-  .ms-md-5 {
-    margin-left: 3rem !important;
-  }
-  .ms-md-auto {
-    margin-left: auto !important;
-  }
-  .p-md-0 {
-    padding: 0 !important;
-  }
-  .p-md-1 {
-    padding: 0.25rem !important;
-  }
-  .p-md-2 {
-    padding: 0.5rem !important;
-  }
-  .p-md-3 {
-    padding: 1rem !important;
-  }
-  .p-md-4 {
-    padding: 1.5rem !important;
-  }
-  .p-md-5 {
-    padding: 3rem !important;
-  }
-  .px-md-0 {
-    padding-right: 0 !important;
-    padding-left: 0 !important;
-  }
-  .px-md-1 {
-    padding-right: 0.25rem !important;
-    padding-left: 0.25rem !important;
-  }
-  .px-md-2 {
-    padding-right: 0.5rem !important;
-    padding-left: 0.5rem !important;
-  }
-  .px-md-3 {
-    padding-right: 1rem !important;
-    padding-left: 1rem !important;
-  }
-  .px-md-4 {
-    padding-right: 1.5rem !important;
-    padding-left: 1.5rem !important;
-  }
-  .px-md-5 {
-    padding-right: 3rem !important;
-    padding-left: 3rem !important;
-  }
-  .py-md-0 {
-    padding-top: 0 !important;
-    padding-bottom: 0 !important;
-  }
-  .py-md-1 {
-    padding-top: 0.25rem !important;
-    padding-bottom: 0.25rem !important;
-  }
-  .py-md-2 {
-    padding-top: 0.5rem !important;
-    padding-bottom: 0.5rem !important;
-  }
-  .py-md-3 {
-    padding-top: 1rem !important;
-    padding-bottom: 1rem !important;
-  }
-  .py-md-4 {
-    padding-top: 1.5rem !important;
-    padding-bottom: 1.5rem !important;
-  }
-  .py-md-5 {
-    padding-top: 3rem !important;
-    padding-bottom: 3rem !important;
-  }
-  .pt-md-0 {
-    padding-top: 0 !important;
-  }
-  .pt-md-1 {
-    padding-top: 0.25rem !important;
-  }
-  .pt-md-2 {
-    padding-top: 0.5rem !important;
-  }
-  .pt-md-3 {
-    padding-top: 1rem !important;
-  }
-  .pt-md-4 {
-    padding-top: 1.5rem !important;
-  }
-  .pt-md-5 {
-    padding-top: 3rem !important;
-  }
-  .pe-md-0 {
-    padding-right: 0 !important;
-  }
-  .pe-md-1 {
-    padding-right: 0.25rem !important;
-  }
-  .pe-md-2 {
-    padding-right: 0.5rem !important;
-  }
-  .pe-md-3 {
-    padding-right: 1rem !important;
-  }
-  .pe-md-4 {
-    padding-right: 1.5rem !important;
-  }
-  .pe-md-5 {
-    padding-right: 3rem !important;
-  }
-  .pb-md-0 {
-    padding-bottom: 0 !important;
-  }
-  .pb-md-1 {
-    padding-bottom: 0.25rem !important;
-  }
-  .pb-md-2 {
-    padding-bottom: 0.5rem !important;
-  }
-  .pb-md-3 {
-    padding-bottom: 1rem !important;
-  }
-  .pb-md-4 {
-    padding-bottom: 1.5rem !important;
-  }
-  .pb-md-5 {
-    padding-bottom: 3rem !important;
-  }
-  .ps-md-0 {
-    padding-left: 0 !important;
-  }
-  .ps-md-1 {
-    padding-left: 0.25rem !important;
-  }
-  .ps-md-2 {
-    padding-left: 0.5rem !important;
-  }
-  .ps-md-3 {
-    padding-left: 1rem !important;
-  }
-  .ps-md-4 {
-    padding-left: 1.5rem !important;
-  }
-  .ps-md-5 {
-    padding-left: 3rem !important;
-  }
-  .gap-md-0 {
-    gap: 0 !important;
-  }
-  .gap-md-1 {
-    gap: 0.25rem !important;
-  }
-  .gap-md-2 {
-    gap: 0.5rem !important;
-  }
-  .gap-md-3 {
-    gap: 1rem !important;
-  }
-  .gap-md-4 {
-    gap: 1.5rem !important;
-  }
-  .gap-md-5 {
-    gap: 3rem !important;
-  }
-  .row-gap-md-0 {
-    row-gap: 0 !important;
-  }
-  .row-gap-md-1 {
-    row-gap: 0.25rem !important;
-  }
-  .row-gap-md-2 {
-    row-gap: 0.5rem !important;
-  }
-  .row-gap-md-3 {
-    row-gap: 1rem !important;
-  }
-  .row-gap-md-4 {
-    row-gap: 1.5rem !important;
-  }
-  .row-gap-md-5 {
-    row-gap: 3rem !important;
-  }
-  .column-gap-md-0 {
-    -moz-column-gap: 0 !important;
-         column-gap: 0 !important;
-  }
-  .column-gap-md-1 {
-    -moz-column-gap: 0.25rem !important;
-         column-gap: 0.25rem !important;
-  }
-  .column-gap-md-2 {
-    -moz-column-gap: 0.5rem !important;
-         column-gap: 0.5rem !important;
-  }
-  .column-gap-md-3 {
-    -moz-column-gap: 1rem !important;
-         column-gap: 1rem !important;
-  }
-  .column-gap-md-4 {
-    -moz-column-gap: 1.5rem !important;
-         column-gap: 1.5rem !important;
-  }
-  .column-gap-md-5 {
-    -moz-column-gap: 3rem !important;
-         column-gap: 3rem !important;
-  }
-  .text-md-start {
-    text-align: left !important;
-  }
-  .text-md-end {
-    text-align: right !important;
-  }
-  .text-md-center {
-    text-align: center !important;
-  }
-}
-@media (min-width: 992px) {
-  .float-lg-start {
-    float: left !important;
-  }
-  .float-lg-end {
-    float: right !important;
-  }
-  .float-lg-none {
-    float: none !important;
-  }
-  .object-fit-lg-contain {
-    -o-object-fit: contain !important;
-       object-fit: contain !important;
-  }
-  .object-fit-lg-cover {
-    -o-object-fit: cover !important;
-       object-fit: cover !important;
-  }
-  .object-fit-lg-fill {
-    -o-object-fit: fill !important;
-       object-fit: fill !important;
-  }
-  .object-fit-lg-scale {
-    -o-object-fit: scale-down !important;
-       object-fit: scale-down !important;
-  }
-  .object-fit-lg-none {
-    -o-object-fit: none !important;
-       object-fit: none !important;
-  }
-  .d-lg-inline {
-    display: inline !important;
-  }
-  .d-lg-inline-block {
-    display: inline-block !important;
-  }
-  .d-lg-block {
-    display: block !important;
-  }
-  .d-lg-grid {
-    display: grid !important;
-  }
-  .d-lg-inline-grid {
-    display: inline-grid !important;
-  }
-  .d-lg-table {
-    display: table !important;
-  }
-  .d-lg-table-row {
-    display: table-row !important;
-  }
-  .d-lg-table-cell {
-    display: table-cell !important;
-  }
-  .d-lg-flex {
-    display: flex !important;
-  }
-  .d-lg-inline-flex {
-    display: inline-flex !important;
-  }
-  .d-lg-none {
-    display: none !important;
-  }
-  .flex-lg-fill {
-    flex: 1 1 auto !important;
-  }
-  .flex-lg-row {
-    flex-direction: row !important;
-  }
-  .flex-lg-column {
-    flex-direction: column !important;
-  }
-  .flex-lg-row-reverse {
-    flex-direction: row-reverse !important;
-  }
-  .flex-lg-column-reverse {
-    flex-direction: column-reverse !important;
-  }
-  .flex-lg-grow-0 {
-    flex-grow: 0 !important;
-  }
-  .flex-lg-grow-1 {
-    flex-grow: 1 !important;
-  }
-  .flex-lg-shrink-0 {
-    flex-shrink: 0 !important;
-  }
-  .flex-lg-shrink-1 {
-    flex-shrink: 1 !important;
-  }
-  .flex-lg-wrap {
-    flex-wrap: wrap !important;
-  }
-  .flex-lg-nowrap {
-    flex-wrap: nowrap !important;
-  }
-  .flex-lg-wrap-reverse {
-    flex-wrap: wrap-reverse !important;
-  }
-  .justify-content-lg-start {
-    justify-content: flex-start !important;
-  }
-  .justify-content-lg-end {
-    justify-content: flex-end !important;
-  }
-  .justify-content-lg-center {
-    justify-content: center !important;
-  }
-  .justify-content-lg-between {
-    justify-content: space-between !important;
-  }
-  .justify-content-lg-around {
-    justify-content: space-around !important;
-  }
-  .justify-content-lg-evenly {
-    justify-content: space-evenly !important;
-  }
-  .align-items-lg-start {
-    align-items: flex-start !important;
-  }
-  .align-items-lg-end {
-    align-items: flex-end !important;
-  }
-  .align-items-lg-center {
-    align-items: center !important;
-  }
-  .align-items-lg-baseline {
-    align-items: baseline !important;
-  }
-  .align-items-lg-stretch {
-    align-items: stretch !important;
-  }
-  .align-content-lg-start {
-    align-content: flex-start !important;
-  }
-  .align-content-lg-end {
-    align-content: flex-end !important;
-  }
-  .align-content-lg-center {
-    align-content: center !important;
-  }
-  .align-content-lg-between {
-    align-content: space-between !important;
-  }
-  .align-content-lg-around {
-    align-content: space-around !important;
-  }
-  .align-content-lg-stretch {
-    align-content: stretch !important;
-  }
-  .align-self-lg-auto {
-    align-self: auto !important;
-  }
-  .align-self-lg-start {
-    align-self: flex-start !important;
-  }
-  .align-self-lg-end {
-    align-self: flex-end !important;
-  }
-  .align-self-lg-center {
-    align-self: center !important;
-  }
-  .align-self-lg-baseline {
-    align-self: baseline !important;
-  }
-  .align-self-lg-stretch {
-    align-self: stretch !important;
-  }
-  .order-lg-first {
-    order: -1 !important;
-  }
-  .order-lg-0 {
-    order: 0 !important;
-  }
-  .order-lg-1 {
-    order: 1 !important;
-  }
-  .order-lg-2 {
-    order: 2 !important;
-  }
-  .order-lg-3 {
-    order: 3 !important;
-  }
-  .order-lg-4 {
-    order: 4 !important;
-  }
-  .order-lg-5 {
-    order: 5 !important;
-  }
-  .order-lg-last {
-    order: 6 !important;
-  }
-  .m-lg-0 {
-    margin: 0 !important;
-  }
-  .m-lg-1 {
-    margin: 0.25rem !important;
-  }
-  .m-lg-2 {
-    margin: 0.5rem !important;
-  }
-  .m-lg-3 {
-    margin: 1rem !important;
-  }
-  .m-lg-4 {
-    margin: 1.5rem !important;
-  }
-  .m-lg-5 {
-    margin: 3rem !important;
-  }
-  .m-lg-auto {
-    margin: auto !important;
-  }
-  .mx-lg-0 {
-    margin-right: 0 !important;
-    margin-left: 0 !important;
-  }
-  .mx-lg-1 {
-    margin-right: 0.25rem !important;
-    margin-left: 0.25rem !important;
-  }
-  .mx-lg-2 {
-    margin-right: 0.5rem !important;
-    margin-left: 0.5rem !important;
-  }
-  .mx-lg-3 {
-    margin-right: 1rem !important;
-    margin-left: 1rem !important;
-  }
-  .mx-lg-4 {
-    margin-right: 1.5rem !important;
-    margin-left: 1.5rem !important;
-  }
-  .mx-lg-5 {
-    margin-right: 3rem !important;
-    margin-left: 3rem !important;
-  }
-  .mx-lg-auto {
-    margin-right: auto !important;
-    margin-left: auto !important;
-  }
-  .my-lg-0 {
-    margin-top: 0 !important;
-    margin-bottom: 0 !important;
-  }
-  .my-lg-1 {
-    margin-top: 0.25rem !important;
-    margin-bottom: 0.25rem !important;
-  }
-  .my-lg-2 {
-    margin-top: 0.5rem !important;
-    margin-bottom: 0.5rem !important;
-  }
-  .my-lg-3 {
-    margin-top: 1rem !important;
-    margin-bottom: 1rem !important;
-  }
-  .my-lg-4 {
-    margin-top: 1.5rem !important;
-    margin-bottom: 1.5rem !important;
-  }
-  .my-lg-5 {
-    margin-top: 3rem !important;
-    margin-bottom: 3rem !important;
-  }
-  .my-lg-auto {
-    margin-top: auto !important;
-    margin-bottom: auto !important;
-  }
-  .mt-lg-0 {
-    margin-top: 0 !important;
-  }
-  .mt-lg-1 {
-    margin-top: 0.25rem !important;
-  }
-  .mt-lg-2 {
-    margin-top: 0.5rem !important;
-  }
-  .mt-lg-3 {
-    margin-top: 1rem !important;
-  }
-  .mt-lg-4 {
-    margin-top: 1.5rem !important;
-  }
-  .mt-lg-5 {
-    margin-top: 3rem !important;
-  }
-  .mt-lg-auto {
-    margin-top: auto !important;
-  }
-  .me-lg-0 {
-    margin-right: 0 !important;
-  }
-  .me-lg-1 {
-    margin-right: 0.25rem !important;
-  }
-  .me-lg-2 {
-    margin-right: 0.5rem !important;
-  }
-  .me-lg-3 {
-    margin-right: 1rem !important;
-  }
-  .me-lg-4 {
-    margin-right: 1.5rem !important;
-  }
-  .me-lg-5 {
-    margin-right: 3rem !important;
-  }
-  .me-lg-auto {
-    margin-right: auto !important;
-  }
-  .mb-lg-0 {
-    margin-bottom: 0 !important;
-  }
-  .mb-lg-1 {
-    margin-bottom: 0.25rem !important;
-  }
-  .mb-lg-2 {
-    margin-bottom: 0.5rem !important;
-  }
-  .mb-lg-3 {
-    margin-bottom: 1rem !important;
-  }
-  .mb-lg-4 {
-    margin-bottom: 1.5rem !important;
-  }
-  .mb-lg-5 {
-    margin-bottom: 3rem !important;
-  }
-  .mb-lg-auto {
-    margin-bottom: auto !important;
-  }
-  .ms-lg-0 {
-    margin-left: 0 !important;
-  }
-  .ms-lg-1 {
-    margin-left: 0.25rem !important;
-  }
-  .ms-lg-2 {
-    margin-left: 0.5rem !important;
-  }
-  .ms-lg-3 {
-    margin-left: 1rem !important;
-  }
-  .ms-lg-4 {
-    margin-left: 1.5rem !important;
-  }
-  .ms-lg-5 {
-    margin-left: 3rem !important;
-  }
-  .ms-lg-auto {
-    margin-left: auto !important;
-  }
-  .p-lg-0 {
-    padding: 0 !important;
-  }
-  .p-lg-1 {
-    padding: 0.25rem !important;
-  }
-  .p-lg-2 {
-    padding: 0.5rem !important;
-  }
-  .p-lg-3 {
-    padding: 1rem !important;
-  }
-  .p-lg-4 {
-    padding: 1.5rem !important;
-  }
-  .p-lg-5 {
-    padding: 3rem !important;
-  }
-  .px-lg-0 {
-    padding-right: 0 !important;
-    padding-left: 0 !important;
-  }
-  .px-lg-1 {
-    padding-right: 0.25rem !important;
-    padding-left: 0.25rem !important;
-  }
-  .px-lg-2 {
-    padding-right: 0.5rem !important;
-    padding-left: 0.5rem !important;
-  }
-  .px-lg-3 {
-    padding-right: 1rem !important;
-    padding-left: 1rem !important;
-  }
-  .px-lg-4 {
-    padding-right: 1.5rem !important;
-    padding-left: 1.5rem !important;
-  }
-  .px-lg-5 {
-    padding-right: 3rem !important;
-    padding-left: 3rem !important;
-  }
-  .py-lg-0 {
-    padding-top: 0 !important;
-    padding-bottom: 0 !important;
-  }
-  .py-lg-1 {
-    padding-top: 0.25rem !important;
-    padding-bottom: 0.25rem !important;
-  }
-  .py-lg-2 {
-    padding-top: 0.5rem !important;
-    padding-bottom: 0.5rem !important;
-  }
-  .py-lg-3 {
-    padding-top: 1rem !important;
-    padding-bottom: 1rem !important;
-  }
-  .py-lg-4 {
-    padding-top: 1.5rem !important;
-    padding-bottom: 1.5rem !important;
-  }
-  .py-lg-5 {
-    padding-top: 3rem !important;
-    padding-bottom: 3rem !important;
-  }
-  .pt-lg-0 {
-    padding-top: 0 !important;
-  }
-  .pt-lg-1 {
-    padding-top: 0.25rem !important;
-  }
-  .pt-lg-2 {
-    padding-top: 0.5rem !important;
-  }
-  .pt-lg-3 {
-    padding-top: 1rem !important;
-  }
-  .pt-lg-4 {
-    padding-top: 1.5rem !important;
-  }
-  .pt-lg-5 {
-    padding-top: 3rem !important;
-  }
-  .pe-lg-0 {
-    padding-right: 0 !important;
-  }
-  .pe-lg-1 {
-    padding-right: 0.25rem !important;
-  }
-  .pe-lg-2 {
-    padding-right: 0.5rem !important;
-  }
-  .pe-lg-3 {
-    padding-right: 1rem !important;
-  }
-  .pe-lg-4 {
-    padding-right: 1.5rem !important;
-  }
-  .pe-lg-5 {
-    padding-right: 3rem !important;
-  }
-  .pb-lg-0 {
-    padding-bottom: 0 !important;
-  }
-  .pb-lg-1 {
-    padding-bottom: 0.25rem !important;
-  }
-  .pb-lg-2 {
-    padding-bottom: 0.5rem !important;
-  }
-  .pb-lg-3 {
-    padding-bottom: 1rem !important;
-  }
-  .pb-lg-4 {
-    padding-bottom: 1.5rem !important;
-  }
-  .pb-lg-5 {
-    padding-bottom: 3rem !important;
-  }
-  .ps-lg-0 {
-    padding-left: 0 !important;
-  }
-  .ps-lg-1 {
-    padding-left: 0.25rem !important;
-  }
-  .ps-lg-2 {
-    padding-left: 0.5rem !important;
-  }
-  .ps-lg-3 {
-    padding-left: 1rem !important;
-  }
-  .ps-lg-4 {
-    padding-left: 1.5rem !important;
-  }
-  .ps-lg-5 {
-    padding-left: 3rem !important;
-  }
-  .gap-lg-0 {
-    gap: 0 !important;
-  }
-  .gap-lg-1 {
-    gap: 0.25rem !important;
-  }
-  .gap-lg-2 {
-    gap: 0.5rem !important;
-  }
-  .gap-lg-3 {
-    gap: 1rem !important;
-  }
-  .gap-lg-4 {
-    gap: 1.5rem !important;
-  }
-  .gap-lg-5 {
-    gap: 3rem !important;
-  }
-  .row-gap-lg-0 {
-    row-gap: 0 !important;
-  }
-  .row-gap-lg-1 {
-    row-gap: 0.25rem !important;
-  }
-  .row-gap-lg-2 {
-    row-gap: 0.5rem !important;
-  }
-  .row-gap-lg-3 {
-    row-gap: 1rem !important;
-  }
-  .row-gap-lg-4 {
-    row-gap: 1.5rem !important;
-  }
-  .row-gap-lg-5 {
-    row-gap: 3rem !important;
-  }
-  .column-gap-lg-0 {
-    -moz-column-gap: 0 !important;
-         column-gap: 0 !important;
-  }
-  .column-gap-lg-1 {
-    -moz-column-gap: 0.25rem !important;
-         column-gap: 0.25rem !important;
-  }
-  .column-gap-lg-2 {
-    -moz-column-gap: 0.5rem !important;
-         column-gap: 0.5rem !important;
-  }
-  .column-gap-lg-3 {
-    -moz-column-gap: 1rem !important;
-         column-gap: 1rem !important;
-  }
-  .column-gap-lg-4 {
-    -moz-column-gap: 1.5rem !important;
-         column-gap: 1.5rem !important;
-  }
-  .column-gap-lg-5 {
-    -moz-column-gap: 3rem !important;
-         column-gap: 3rem !important;
-  }
-  .text-lg-start {
-    text-align: left !important;
-  }
-  .text-lg-end {
-    text-align: right !important;
-  }
-  .text-lg-center {
-    text-align: center !important;
-  }
-}
-@media (min-width: 1200px) {
-  .float-xl-start {
-    float: left !important;
-  }
-  .float-xl-end {
-    float: right !important;
-  }
-  .float-xl-none {
-    float: none !important;
-  }
-  .object-fit-xl-contain {
-    -o-object-fit: contain !important;
-       object-fit: contain !important;
-  }
-  .object-fit-xl-cover {
-    -o-object-fit: cover !important;
-       object-fit: cover !important;
-  }
-  .object-fit-xl-fill {
-    -o-object-fit: fill !important;
-       object-fit: fill !important;
-  }
-  .object-fit-xl-scale {
-    -o-object-fit: scale-down !important;
-       object-fit: scale-down !important;
-  }
-  .object-fit-xl-none {
-    -o-object-fit: none !important;
-       object-fit: none !important;
-  }
-  .d-xl-inline {
-    display: inline !important;
-  }
-  .d-xl-inline-block {
-    display: inline-block !important;
-  }
-  .d-xl-block {
-    display: block !important;
-  }
-  .d-xl-grid {
-    display: grid !important;
-  }
-  .d-xl-inline-grid {
-    display: inline-grid !important;
-  }
-  .d-xl-table {
-    display: table !important;
-  }
-  .d-xl-table-row {
-    display: table-row !important;
-  }
-  .d-xl-table-cell {
-    display: table-cell !important;
-  }
-  .d-xl-flex {
-    display: flex !important;
-  }
-  .d-xl-inline-flex {
-    display: inline-flex !important;
-  }
-  .d-xl-none {
-    display: none !important;
-  }
-  .flex-xl-fill {
-    flex: 1 1 auto !important;
-  }
-  .flex-xl-row {
-    flex-direction: row !important;
-  }
-  .flex-xl-column {
-    flex-direction: column !important;
-  }
-  .flex-xl-row-reverse {
-    flex-direction: row-reverse !important;
-  }
-  .flex-xl-column-reverse {
-    flex-direction: column-reverse !important;
-  }
-  .flex-xl-grow-0 {
-    flex-grow: 0 !important;
-  }
-  .flex-xl-grow-1 {
-    flex-grow: 1 !important;
-  }
-  .flex-xl-shrink-0 {
-    flex-shrink: 0 !important;
-  }
-  .flex-xl-shrink-1 {
-    flex-shrink: 1 !important;
-  }
-  .flex-xl-wrap {
-    flex-wrap: wrap !important;
-  }
-  .flex-xl-nowrap {
-    flex-wrap: nowrap !important;
-  }
-  .flex-xl-wrap-reverse {
-    flex-wrap: wrap-reverse !important;
-  }
-  .justify-content-xl-start {
-    justify-content: flex-start !important;
-  }
-  .justify-content-xl-end {
-    justify-content: flex-end !important;
-  }
-  .justify-content-xl-center {
-    justify-content: center !important;
-  }
-  .justify-content-xl-between {
-    justify-content: space-between !important;
-  }
-  .justify-content-xl-around {
-    justify-content: space-around !important;
-  }
-  .justify-content-xl-evenly {
-    justify-content: space-evenly !important;
-  }
-  .align-items-xl-start {
-    align-items: flex-start !important;
-  }
-  .align-items-xl-end {
-    align-items: flex-end !important;
-  }
-  .align-items-xl-center {
-    align-items: center !important;
-  }
-  .align-items-xl-baseline {
-    align-items: baseline !important;
-  }
-  .align-items-xl-stretch {
-    align-items: stretch !important;
-  }
-  .align-content-xl-start {
-    align-content: flex-start !important;
-  }
-  .align-content-xl-end {
-    align-content: flex-end !important;
-  }
-  .align-content-xl-center {
-    align-content: center !important;
-  }
-  .align-content-xl-between {
-    align-content: space-between !important;
-  }
-  .align-content-xl-around {
-    align-content: space-around !important;
-  }
-  .align-content-xl-stretch {
-    align-content: stretch !important;
-  }
-  .align-self-xl-auto {
-    align-self: auto !important;
-  }
-  .align-self-xl-start {
-    align-self: flex-start !important;
-  }
-  .align-self-xl-end {
-    align-self: flex-end !important;
-  }
-  .align-self-xl-center {
-    align-self: center !important;
-  }
-  .align-self-xl-baseline {
-    align-self: baseline !important;
-  }
-  .align-self-xl-stretch {
-    align-self: stretch !important;
-  }
-  .order-xl-first {
-    order: -1 !important;
-  }
-  .order-xl-0 {
-    order: 0 !important;
-  }
-  .order-xl-1 {
-    order: 1 !important;
-  }
-  .order-xl-2 {
-    order: 2 !important;
-  }
-  .order-xl-3 {
-    order: 3 !important;
-  }
-  .order-xl-4 {
-    order: 4 !important;
-  }
-  .order-xl-5 {
-    order: 5 !important;
-  }
-  .order-xl-last {
-    order: 6 !important;
-  }
-  .m-xl-0 {
-    margin: 0 !important;
-  }
-  .m-xl-1 {
-    margin: 0.25rem !important;
-  }
-  .m-xl-2 {
-    margin: 0.5rem !important;
-  }
-  .m-xl-3 {
-    margin: 1rem !important;
-  }
-  .m-xl-4 {
-    margin: 1.5rem !important;
-  }
-  .m-xl-5 {
-    margin: 3rem !important;
-  }
-  .m-xl-auto {
-    margin: auto !important;
-  }
-  .mx-xl-0 {
-    margin-right: 0 !important;
-    margin-left: 0 !important;
-  }
-  .mx-xl-1 {
-    margin-right: 0.25rem !important;
-    margin-left: 0.25rem !important;
-  }
-  .mx-xl-2 {
-    margin-right: 0.5rem !important;
-    margin-left: 0.5rem !important;
-  }
-  .mx-xl-3 {
-    margin-right: 1rem !important;
-    margin-left: 1rem !important;
-  }
-  .mx-xl-4 {
-    margin-right: 1.5rem !important;
-    margin-left: 1.5rem !important;
-  }
-  .mx-xl-5 {
-    margin-right: 3rem !important;
-    margin-left: 3rem !important;
-  }
-  .mx-xl-auto {
-    margin-right: auto !important;
-    margin-left: auto !important;
-  }
-  .my-xl-0 {
-    margin-top: 0 !important;
-    margin-bottom: 0 !important;
-  }
-  .my-xl-1 {
-    margin-top: 0.25rem !important;
-    margin-bottom: 0.25rem !important;
-  }
-  .my-xl-2 {
-    margin-top: 0.5rem !important;
-    margin-bottom: 0.5rem !important;
-  }
-  .my-xl-3 {
-    margin-top: 1rem !important;
-    margin-bottom: 1rem !important;
-  }
-  .my-xl-4 {
-    margin-top: 1.5rem !important;
-    margin-bottom: 1.5rem !important;
-  }
-  .my-xl-5 {
-    margin-top: 3rem !important;
-    margin-bottom: 3rem !important;
-  }
-  .my-xl-auto {
-    margin-top: auto !important;
-    margin-bottom: auto !important;
-  }
-  .mt-xl-0 {
-    margin-top: 0 !important;
-  }
-  .mt-xl-1 {
-    margin-top: 0.25rem !important;
-  }
-  .mt-xl-2 {
-    margin-top: 0.5rem !important;
-  }
-  .mt-xl-3 {
-    margin-top: 1rem !important;
-  }
-  .mt-xl-4 {
-    margin-top: 1.5rem !important;
-  }
-  .mt-xl-5 {
-    margin-top: 3rem !important;
-  }
-  .mt-xl-auto {
-    margin-top: auto !important;
-  }
-  .me-xl-0 {
-    margin-right: 0 !important;
-  }
-  .me-xl-1 {
-    margin-right: 0.25rem !important;
-  }
-  .me-xl-2 {
-    margin-right: 0.5rem !important;
-  }
-  .me-xl-3 {
-    margin-right: 1rem !important;
-  }
-  .me-xl-4 {
-    margin-right: 1.5rem !important;
-  }
-  .me-xl-5 {
-    margin-right: 3rem !important;
-  }
-  .me-xl-auto {
-    margin-right: auto !important;
-  }
-  .mb-xl-0 {
-    margin-bottom: 0 !important;
-  }
-  .mb-xl-1 {
-    margin-bottom: 0.25rem !important;
-  }
-  .mb-xl-2 {
-    margin-bottom: 0.5rem !important;
-  }
-  .mb-xl-3 {
-    margin-bottom: 1rem !important;
-  }
-  .mb-xl-4 {
-    margin-bottom: 1.5rem !important;
-  }
-  .mb-xl-5 {
-    margin-bottom: 3rem !important;
-  }
-  .mb-xl-auto {
-    margin-bottom: auto !important;
-  }
-  .ms-xl-0 {
-    margin-left: 0 !important;
-  }
-  .ms-xl-1 {
-    margin-left: 0.25rem !important;
-  }
-  .ms-xl-2 {
-    margin-left: 0.5rem !important;
-  }
-  .ms-xl-3 {
-    margin-left: 1rem !important;
-  }
-  .ms-xl-4 {
-    margin-left: 1.5rem !important;
-  }
-  .ms-xl-5 {
-    margin-left: 3rem !important;
-  }
-  .ms-xl-auto {
-    margin-left: auto !important;
-  }
-  .p-xl-0 {
-    padding: 0 !important;
-  }
-  .p-xl-1 {
-    padding: 0.25rem !important;
-  }
-  .p-xl-2 {
-    padding: 0.5rem !important;
-  }
-  .p-xl-3 {
-    padding: 1rem !important;
-  }
-  .p-xl-4 {
-    padding: 1.5rem !important;
-  }
-  .p-xl-5 {
-    padding: 3rem !important;
-  }
-  .px-xl-0 {
-    padding-right: 0 !important;
-    padding-left: 0 !important;
-  }
-  .px-xl-1 {
-    padding-right: 0.25rem !important;
-    padding-left: 0.25rem !important;
-  }
-  .px-xl-2 {
-    padding-right: 0.5rem !important;
-    padding-left: 0.5rem !important;
-  }
-  .px-xl-3 {
-    padding-right: 1rem !important;
-    padding-left: 1rem !important;
-  }
-  .px-xl-4 {
-    padding-right: 1.5rem !important;
-    padding-left: 1.5rem !important;
-  }
-  .px-xl-5 {
-    padding-right: 3rem !important;
-    padding-left: 3rem !important;
-  }
-  .py-xl-0 {
-    padding-top: 0 !important;
-    padding-bottom: 0 !important;
-  }
-  .py-xl-1 {
-    padding-top: 0.25rem !important;
-    padding-bottom: 0.25rem !important;
-  }
-  .py-xl-2 {
-    padding-top: 0.5rem !important;
-    padding-bottom: 0.5rem !important;
-  }
-  .py-xl-3 {
-    padding-top: 1rem !important;
-    padding-bottom: 1rem !important;
-  }
-  .py-xl-4 {
-    padding-top: 1.5rem !important;
-    padding-bottom: 1.5rem !important;
-  }
-  .py-xl-5 {
-    padding-top: 3rem !important;
-    padding-bottom: 3rem !important;
-  }
-  .pt-xl-0 {
-    padding-top: 0 !important;
-  }
-  .pt-xl-1 {
-    padding-top: 0.25rem !important;
-  }
-  .pt-xl-2 {
-    padding-top: 0.5rem !important;
-  }
-  .pt-xl-3 {
-    padding-top: 1rem !important;
-  }
-  .pt-xl-4 {
-    padding-top: 1.5rem !important;
-  }
-  .pt-xl-5 {
-    padding-top: 3rem !important;
-  }
-  .pe-xl-0 {
-    padding-right: 0 !important;
-  }
-  .pe-xl-1 {
-    padding-right: 0.25rem !important;
-  }
-  .pe-xl-2 {
-    padding-right: 0.5rem !important;
-  }
-  .pe-xl-3 {
-    padding-right: 1rem !important;
-  }
-  .pe-xl-4 {
-    padding-right: 1.5rem !important;
-  }
-  .pe-xl-5 {
-    padding-right: 3rem !important;
-  }
-  .pb-xl-0 {
-    padding-bottom: 0 !important;
-  }
-  .pb-xl-1 {
-    padding-bottom: 0.25rem !important;
-  }
-  .pb-xl-2 {
-    padding-bottom: 0.5rem !important;
-  }
-  .pb-xl-3 {
-    padding-bottom: 1rem !important;
-  }
-  .pb-xl-4 {
-    padding-bottom: 1.5rem !important;
-  }
-  .pb-xl-5 {
-    padding-bottom: 3rem !important;
-  }
-  .ps-xl-0 {
-    padding-left: 0 !important;
-  }
-  .ps-xl-1 {
-    padding-left: 0.25rem !important;
-  }
-  .ps-xl-2 {
-    padding-left: 0.5rem !important;
-  }
-  .ps-xl-3 {
-    padding-left: 1rem !important;
-  }
-  .ps-xl-4 {
-    padding-left: 1.5rem !important;
-  }
-  .ps-xl-5 {
-    padding-left: 3rem !important;
-  }
-  .gap-xl-0 {
-    gap: 0 !important;
-  }
-  .gap-xl-1 {
-    gap: 0.25rem !important;
-  }
-  .gap-xl-2 {
-    gap: 0.5rem !important;
-  }
-  .gap-xl-3 {
-    gap: 1rem !important;
-  }
-  .gap-xl-4 {
-    gap: 1.5rem !important;
-  }
-  .gap-xl-5 {
-    gap: 3rem !important;
-  }
-  .row-gap-xl-0 {
-    row-gap: 0 !important;
-  }
-  .row-gap-xl-1 {
-    row-gap: 0.25rem !important;
-  }
-  .row-gap-xl-2 {
-    row-gap: 0.5rem !important;
-  }
-  .row-gap-xl-3 {
-    row-gap: 1rem !important;
-  }
-  .row-gap-xl-4 {
-    row-gap: 1.5rem !important;
-  }
-  .row-gap-xl-5 {
-    row-gap: 3rem !important;
-  }
-  .column-gap-xl-0 {
-    -moz-column-gap: 0 !important;
-         column-gap: 0 !important;
-  }
-  .column-gap-xl-1 {
-    -moz-column-gap: 0.25rem !important;
-         column-gap: 0.25rem !important;
-  }
-  .column-gap-xl-2 {
-    -moz-column-gap: 0.5rem !important;
-         column-gap: 0.5rem !important;
-  }
-  .column-gap-xl-3 {
-    -moz-column-gap: 1rem !important;
-         column-gap: 1rem !important;
-  }
-  .column-gap-xl-4 {
-    -moz-column-gap: 1.5rem !important;
-         column-gap: 1.5rem !important;
-  }
-  .column-gap-xl-5 {
-    -moz-column-gap: 3rem !important;
-         column-gap: 3rem !important;
-  }
-  .text-xl-start {
-    text-align: left !important;
-  }
-  .text-xl-end {
-    text-align: right !important;
-  }
-  .text-xl-center {
-    text-align: center !important;
-  }
-}
-@media (min-width: 1400px) {
-  .float-xxl-start {
-    float: left !important;
-  }
-  .float-xxl-end {
-    float: right !important;
-  }
-  .float-xxl-none {
-    float: none !important;
-  }
-  .object-fit-xxl-contain {
-    -o-object-fit: contain !important;
-       object-fit: contain !important;
-  }
-  .object-fit-xxl-cover {
-    -o-object-fit: cover !important;
-       object-fit: cover !important;
-  }
-  .object-fit-xxl-fill {
-    -o-object-fit: fill !important;
-       object-fit: fill !important;
-  }
-  .object-fit-xxl-scale {
-    -o-object-fit: scale-down !important;
-       object-fit: scale-down !important;
-  }
-  .object-fit-xxl-none {
-    -o-object-fit: none !important;
-       object-fit: none !important;
-  }
-  .d-xxl-inline {
-    display: inline !important;
-  }
-  .d-xxl-inline-block {
-    display: inline-block !important;
-  }
-  .d-xxl-block {
-    display: block !important;
-  }
-  .d-xxl-grid {
-    display: grid !important;
-  }
-  .d-xxl-inline-grid {
-    display: inline-grid !important;
-  }
-  .d-xxl-table {
-    display: table !important;
-  }
-  .d-xxl-table-row {
-    display: table-row !important;
-  }
-  .d-xxl-table-cell {
-    display: table-cell !important;
-  }
-  .d-xxl-flex {
-    display: flex !important;
-  }
-  .d-xxl-inline-flex {
-    display: inline-flex !important;
-  }
-  .d-xxl-none {
-    display: none !important;
-  }
-  .flex-xxl-fill {
-    flex: 1 1 auto !important;
-  }
-  .flex-xxl-row {
-    flex-direction: row !important;
-  }
-  .flex-xxl-column {
-    flex-direction: column !important;
-  }
-  .flex-xxl-row-reverse {
-    flex-direction: row-reverse !important;
-  }
-  .flex-xxl-column-reverse {
-    flex-direction: column-reverse !important;
-  }
-  .flex-xxl-grow-0 {
-    flex-grow: 0 !important;
-  }
-  .flex-xxl-grow-1 {
-    flex-grow: 1 !important;
-  }
-  .flex-xxl-shrink-0 {
-    flex-shrink: 0 !important;
-  }
-  .flex-xxl-shrink-1 {
-    flex-shrink: 1 !important;
-  }
-  .flex-xxl-wrap {
-    flex-wrap: wrap !important;
-  }
-  .flex-xxl-nowrap {
-    flex-wrap: nowrap !important;
-  }
-  .flex-xxl-wrap-reverse {
-    flex-wrap: wrap-reverse !important;
-  }
-  .justify-content-xxl-start {
-    justify-content: flex-start !important;
-  }
-  .justify-content-xxl-end {
-    justify-content: flex-end !important;
-  }
-  .justify-content-xxl-center {
-    justify-content: center !important;
-  }
-  .justify-content-xxl-between {
-    justify-content: space-between !important;
-  }
-  .justify-content-xxl-around {
-    justify-content: space-around !important;
-  }
-  .justify-content-xxl-evenly {
-    justify-content: space-evenly !important;
-  }
-  .align-items-xxl-start {
-    align-items: flex-start !important;
-  }
-  .align-items-xxl-end {
-    align-items: flex-end !important;
-  }
-  .align-items-xxl-center {
-    align-items: center !important;
-  }
-  .align-items-xxl-baseline {
-    align-items: baseline !important;
-  }
-  .align-items-xxl-stretch {
-    align-items: stretch !important;
-  }
-  .align-content-xxl-start {
-    align-content: flex-start !important;
-  }
-  .align-content-xxl-end {
-    align-content: flex-end !important;
-  }
-  .align-content-xxl-center {
-    align-content: center !important;
-  }
-  .align-content-xxl-between {
-    align-content: space-between !important;
-  }
-  .align-content-xxl-around {
-    align-content: space-around !important;
-  }
-  .align-content-xxl-stretch {
-    align-content: stretch !important;
-  }
-  .align-self-xxl-auto {
-    align-self: auto !important;
-  }
-  .align-self-xxl-start {
-    align-self: flex-start !important;
-  }
-  .align-self-xxl-end {
-    align-self: flex-end !important;
-  }
-  .align-self-xxl-center {
-    align-self: center !important;
-  }
-  .align-self-xxl-baseline {
-    align-self: baseline !important;
-  }
-  .align-self-xxl-stretch {
-    align-self: stretch !important;
-  }
-  .order-xxl-first {
-    order: -1 !important;
-  }
-  .order-xxl-0 {
-    order: 0 !important;
-  }
-  .order-xxl-1 {
-    order: 1 !important;
-  }
-  .order-xxl-2 {
-    order: 2 !important;
-  }
-  .order-xxl-3 {
-    order: 3 !important;
-  }
-  .order-xxl-4 {
-    order: 4 !important;
-  }
-  .order-xxl-5 {
-    order: 5 !important;
-  }
-  .order-xxl-last {
-    order: 6 !important;
-  }
-  .m-xxl-0 {
-    margin: 0 !important;
-  }
-  .m-xxl-1 {
-    margin: 0.25rem !important;
-  }
-  .m-xxl-2 {
-    margin: 0.5rem !important;
-  }
-  .m-xxl-3 {
-    margin: 1rem !important;
-  }
-  .m-xxl-4 {
-    margin: 1.5rem !important;
-  }
-  .m-xxl-5 {
-    margin: 3rem !important;
-  }
-  .m-xxl-auto {
-    margin: auto !important;
-  }
-  .mx-xxl-0 {
-    margin-right: 0 !important;
-    margin-left: 0 !important;
-  }
-  .mx-xxl-1 {
-    margin-right: 0.25rem !important;
-    margin-left: 0.25rem !important;
-  }
-  .mx-xxl-2 {
-    margin-right: 0.5rem !important;
-    margin-left: 0.5rem !important;
-  }
-  .mx-xxl-3 {
-    margin-right: 1rem !important;
-    margin-left: 1rem !important;
-  }
-  .mx-xxl-4 {
-    margin-right: 1.5rem !important;
-    margin-left: 1.5rem !important;
-  }
-  .mx-xxl-5 {
-    margin-right: 3rem !important;
-    margin-left: 3rem !important;
-  }
-  .mx-xxl-auto {
-    margin-right: auto !important;
-    margin-left: auto !important;
-  }
-  .my-xxl-0 {
-    margin-top: 0 !important;
-    margin-bottom: 0 !important;
-  }
-  .my-xxl-1 {
-    margin-top: 0.25rem !important;
-    margin-bottom: 0.25rem !important;
-  }
-  .my-xxl-2 {
-    margin-top: 0.5rem !important;
-    margin-bottom: 0.5rem !important;
-  }
-  .my-xxl-3 {
-    margin-top: 1rem !important;
-    margin-bottom: 1rem !important;
-  }
-  .my-xxl-4 {
-    margin-top: 1.5rem !important;
-    margin-bottom: 1.5rem !important;
-  }
-  .my-xxl-5 {
-    margin-top: 3rem !important;
-    margin-bottom: 3rem !important;
-  }
-  .my-xxl-auto {
-    margin-top: auto !important;
-    margin-bottom: auto !important;
-  }
-  .mt-xxl-0 {
-    margin-top: 0 !important;
-  }
-  .mt-xxl-1 {
-    margin-top: 0.25rem !important;
-  }
-  .mt-xxl-2 {
-    margin-top: 0.5rem !important;
-  }
-  .mt-xxl-3 {
-    margin-top: 1rem !important;
-  }
-  .mt-xxl-4 {
-    margin-top: 1.5rem !important;
-  }
-  .mt-xxl-5 {
-    margin-top: 3rem !important;
-  }
-  .mt-xxl-auto {
-    margin-top: auto !important;
-  }
-  .me-xxl-0 {
-    margin-right: 0 !important;
-  }
-  .me-xxl-1 {
-    margin-right: 0.25rem !important;
-  }
-  .me-xxl-2 {
-    margin-right: 0.5rem !important;
-  }
-  .me-xxl-3 {
-    margin-right: 1rem !important;
-  }
-  .me-xxl-4 {
-    margin-right: 1.5rem !important;
-  }
-  .me-xxl-5 {
-    margin-right: 3rem !important;
-  }
-  .me-xxl-auto {
-    margin-right: auto !important;
-  }
-  .mb-xxl-0 {
-    margin-bottom: 0 !important;
-  }
-  .mb-xxl-1 {
-    margin-bottom: 0.25rem !important;
-  }
-  .mb-xxl-2 {
-    margin-bottom: 0.5rem !important;
-  }
-  .mb-xxl-3 {
-    margin-bottom: 1rem !important;
-  }
-  .mb-xxl-4 {
-    margin-bottom: 1.5rem !important;
-  }
-  .mb-xxl-5 {
-    margin-bottom: 3rem !important;
-  }
-  .mb-xxl-auto {
-    margin-bottom: auto !important;
-  }
-  .ms-xxl-0 {
-    margin-left: 0 !important;
-  }
-  .ms-xxl-1 {
-    margin-left: 0.25rem !important;
-  }
-  .ms-xxl-2 {
-    margin-left: 0.5rem !important;
-  }
-  .ms-xxl-3 {
-    margin-left: 1rem !important;
-  }
-  .ms-xxl-4 {
-    margin-left: 1.5rem !important;
-  }
-  .ms-xxl-5 {
-    margin-left: 3rem !important;
-  }
-  .ms-xxl-auto {
-    margin-left: auto !important;
-  }
-  .p-xxl-0 {
-    padding: 0 !important;
-  }
-  .p-xxl-1 {
-    padding: 0.25rem !important;
-  }
-  .p-xxl-2 {
-    padding: 0.5rem !important;
-  }
-  .p-xxl-3 {
-    padding: 1rem !important;
-  }
-  .p-xxl-4 {
-    padding: 1.5rem !important;
-  }
-  .p-xxl-5 {
-    padding: 3rem !important;
-  }
-  .px-xxl-0 {
-    padding-right: 0 !important;
-    padding-left: 0 !important;
-  }
-  .px-xxl-1 {
-    padding-right: 0.25rem !important;
-    padding-left: 0.25rem !important;
-  }
-  .px-xxl-2 {
-    padding-right: 0.5rem !important;
-    padding-left: 0.5rem !important;
-  }
-  .px-xxl-3 {
-    padding-right: 1rem !important;
-    padding-left: 1rem !important;
-  }
-  .px-xxl-4 {
-    padding-right: 1.5rem !important;
-    padding-left: 1.5rem !important;
-  }
-  .px-xxl-5 {
-    padding-right: 3rem !important;
-    padding-left: 3rem !important;
-  }
-  .py-xxl-0 {
-    padding-top: 0 !important;
-    padding-bottom: 0 !important;
-  }
-  .py-xxl-1 {
-    padding-top: 0.25rem !important;
-    padding-bottom: 0.25rem !important;
-  }
-  .py-xxl-2 {
-    padding-top: 0.5rem !important;
-    padding-bottom: 0.5rem !important;
-  }
-  .py-xxl-3 {
-    padding-top: 1rem !important;
-    padding-bottom: 1rem !important;
-  }
-  .py-xxl-4 {
-    padding-top: 1.5rem !important;
-    padding-bottom: 1.5rem !important;
-  }
-  .py-xxl-5 {
-    padding-top: 3rem !important;
-    padding-bottom: 3rem !important;
-  }
-  .pt-xxl-0 {
-    padding-top: 0 !important;
-  }
-  .pt-xxl-1 {
-    padding-top: 0.25rem !important;
-  }
-  .pt-xxl-2 {
-    padding-top: 0.5rem !important;
-  }
-  .pt-xxl-3 {
-    padding-top: 1rem !important;
-  }
-  .pt-xxl-4 {
-    padding-top: 1.5rem !important;
-  }
-  .pt-xxl-5 {
-    padding-top: 3rem !important;
-  }
-  .pe-xxl-0 {
-    padding-right: 0 !important;
-  }
-  .pe-xxl-1 {
-    padding-right: 0.25rem !important;
-  }
-  .pe-xxl-2 {
-    padding-right: 0.5rem !important;
-  }
-  .pe-xxl-3 {
-    padding-right: 1rem !important;
-  }
-  .pe-xxl-4 {
-    padding-right: 1.5rem !important;
-  }
-  .pe-xxl-5 {
-    padding-right: 3rem !important;
-  }
-  .pb-xxl-0 {
-    padding-bottom: 0 !important;
-  }
-  .pb-xxl-1 {
-    padding-bottom: 0.25rem !important;
-  }
-  .pb-xxl-2 {
-    padding-bottom: 0.5rem !important;
-  }
-  .pb-xxl-3 {
-    padding-bottom: 1rem !important;
-  }
-  .pb-xxl-4 {
-    padding-bottom: 1.5rem !important;
-  }
-  .pb-xxl-5 {
-    padding-bottom: 3rem !important;
-  }
-  .ps-xxl-0 {
-    padding-left: 0 !important;
-  }
-  .ps-xxl-1 {
-    padding-left: 0.25rem !important;
-  }
-  .ps-xxl-2 {
-    padding-left: 0.5rem !important;
-  }
-  .ps-xxl-3 {
-    padding-left: 1rem !important;
-  }
-  .ps-xxl-4 {
-    padding-left: 1.5rem !important;
-  }
-  .ps-xxl-5 {
-    padding-left: 3rem !important;
-  }
-  .gap-xxl-0 {
-    gap: 0 !important;
-  }
-  .gap-xxl-1 {
-    gap: 0.25rem !important;
-  }
-  .gap-xxl-2 {
-    gap: 0.5rem !important;
-  }
-  .gap-xxl-3 {
-    gap: 1rem !important;
-  }
-  .gap-xxl-4 {
-    gap: 1.5rem !important;
-  }
-  .gap-xxl-5 {
-    gap: 3rem !important;
-  }
-  .row-gap-xxl-0 {
-    row-gap: 0 !important;
-  }
-  .row-gap-xxl-1 {
-    row-gap: 0.25rem !important;
-  }
-  .row-gap-xxl-2 {
-    row-gap: 0.5rem !important;
-  }
-  .row-gap-xxl-3 {
-    row-gap: 1rem !important;
-  }
-  .row-gap-xxl-4 {
-    row-gap: 1.5rem !important;
-  }
-  .row-gap-xxl-5 {
-    row-gap: 3rem !important;
-  }
-  .column-gap-xxl-0 {
-    -moz-column-gap: 0 !important;
-         column-gap: 0 !important;
-  }
-  .column-gap-xxl-1 {
-    -moz-column-gap: 0.25rem !important;
-         column-gap: 0.25rem !important;
-  }
-  .column-gap-xxl-2 {
-    -moz-column-gap: 0.5rem !important;
-         column-gap: 0.5rem !important;
-  }
-  .column-gap-xxl-3 {
-    -moz-column-gap: 1rem !important;
-         column-gap: 1rem !important;
-  }
-  .column-gap-xxl-4 {
-    -moz-column-gap: 1.5rem !important;
-         column-gap: 1.5rem !important;
-  }
-  .column-gap-xxl-5 {
-    -moz-column-gap: 3rem !important;
-         column-gap: 3rem !important;
-  }
-  .text-xxl-start {
-    text-align: left !important;
-  }
-  .text-xxl-end {
-    text-align: right !important;
-  }
-  .text-xxl-center {
-    text-align: center !important;
-  }
-}
-@media (min-width: 1200px) {
-  .fs-1 {
-    font-size: 2.1875rem !important;
-  }
-  .fs-2 {
-    font-size: 1.75rem !important;
-  }
-  .fs-3 {
-    font-size: 1.53125rem !important;
-  }
-  .fs-4 {
-    font-size: 1.3125rem !important;
-  }
-}
-@media print {
-  .d-print-inline {
-    display: inline !important;
-  }
-  .d-print-inline-block {
-    display: inline-block !important;
-  }
-  .d-print-block {
-    display: block !important;
-  }
-  .d-print-grid {
-    display: grid !important;
-  }
-  .d-print-inline-grid {
-    display: inline-grid !important;
-  }
-  .d-print-table {
-    display: table !important;
-  }
-  .d-print-table-row {
-    display: table-row !important;
-  }
-  .d-print-table-cell {
-    display: table-cell !important;
-  }
-  .d-print-flex {
-    display: flex !important;
-  }
-  .d-print-inline-flex {
-    display: inline-flex !important;
-  }
-  .d-print-none {
-    display: none !important;
-  }
-}
+/* big additions here */
 .bg-blue {
-  background-color: rgba(13, 110, 253, 0.75) !important;
+    background-color: rgba(13, 110, 253, 0.75) !important;
 }
 
 .bg-indigo {
-  background-color: rgba(102, 16, 242, 0.75) !important;
+    background-color: rgba(102, 16, 242, 0.75) !important;
 }
 
 .bg-purple {
-  background-color: rgba(111, 66, 193, 0.75) !important;
+    background-color: rgba(111, 66, 193, 0.75) !important;
 }
 
 .bg-pink {
-  background-color: rgba(214, 51, 132, 0.75) !important;
+    background-color: rgba(214, 51, 132, 0.75) !important;
 }
 
 .bg-orange {
-  background-color: rgba(253, 126, 20, 0.75) !important;
+    background-color: rgba(253, 126, 20, 0.75) !important;
 }
 
 .bg-yellow {
-  background-color: rgba(255, 193, 7, 0.75) !important;
+    background-color: rgba(255, 193, 7, 0.75) !important;
 }
 
 .bg-teal {
-  background-color: rgba(32, 201, 151, 0.75) !important;
+    background-color: rgba(32, 201, 151, 0.75) !important;
 }
 
 .bg-cyan {
-  background-color: rgba(13, 202, 240, 0.75) !important;
+    background-color: rgba(13, 202, 240, 0.75) !important;
 }
 
 .text-blue {
-  color: #0d6efd !important;
+    color: #0d6efd !important;
 }
 
 .text-indigo {
-  color: #6610f2 !important;
+    color: #6610f2 !important;
 }
 
 .text-purple {
-  color: #6f42c1 !important;
+    color: #6f42c1 !important;
 }
 
 .text-pink {
-  color: #d63384 !important;
+    color: #d63384 !important;
 }
 
 .text-orange {
-  color: #fd7e14 !important;
+    color: #fd7e14 !important;
 }
 
 .text-yellow {
-  color: #ffc107 !important;
+    color: #ffc107 !important;
 }
 
 .text-teal {
-  color: #20c997 !important;
+    color: #20c997 !important;
 }
 
 .text-cyan {
-  color: #0dcaf0 !important;
+    color: #0dcaf0 !important;
 }
 
-html, body {
-  height: 100%;
+html,
+body {
+    height: 100%;
 }
 
 body {
-  font-family: "Poppins", sans-serif;
-  position: relative;
-  color: black;
-  background-color: #f5f4fe;
-  overflow-x: hidden;
+    font-family: "Poppins", sans-serif;
+    position: relative;
+    color: black;
+    background-color: #f5f4fe;
+    overflow-x: hidden;
 }
+
 body.no-scroll {
-  overflow: hidden !important;
+    overflow: hidden !important;
 }
+
 body:after {
-  content: "";
-  position: fixed;
-  top: 0;
-  right: 0;
-  left: 0;
-  bottom: 0;
-  z-index: 999;
-  background: rgba(0, 0, 0, 0.2);
-  visibility: hidden;
-  opacity: 0;
-  transition: all 0.3s;
+    content: "";
+    position: fixed;
+    top: 0;
+    right: 0;
+    left: 0;
+    bottom: 0;
+    z-index: 999;
+    background: rgba(0, 0, 0, 0.2);
+    visibility: hidden;
+    opacity: 0;
+    transition: all 0.3s;
 }
+
 body.plate-show:after {
-  visibility: visible;
-  opacity: 1;
+    visibility: visible;
+    opacity: 1;
 }
 
 * {
-  min-width: 0;
+    min-width: 0;
 }
 
 .header {
-  z-index: 997;
-  display: flex;
-  height: 90px;
-  align-items: center;
-  padding: 0 20px;
-  background-color: #f5f4fe;
-  position: sticky;
-  top: 0;
+    z-index: 997;
+    display: flex;
+    height: 90px;
+    align-items: center;
+    padding: 0 20px;
+    background-color: #f5f4fe;
+    position: sticky;
+    top: 0;
 }
-.header.sticky-top + .page-header.sticky-top {
-  top: 90px;
+
+.header.sticky-top+.page-header.sticky-top {
+    top: 90px;
 }
+
 .header .logo {
-  display: none;
-  margin-right: 70px;
+    display: none;
+    margin-right: 70px;
 }
+
 .header .page-title {
-  font-size: 25px;
-  display: flex;
-  align-items: center;
-  font-weight: 500;
-  margin-right: 70px;
+    font-size: 25px;
+    display: flex;
+    align-items: center;
+    font-weight: 500;
+    margin-right: 70px;
 }
+
 .header .search-form {
-  flex: 1;
-  margin-right: 50px;
+    flex: 1;
+    margin-right: 50px;
 }
+
 .header .search-form .input-group {
-  background-color: white;
-  border-radius: 0.5rem;
+    background-color: white;
+    border-radius: 0.5rem;
 }
+
 .header .search-form .btn {
-  border: none;
-  background: none !important;
+    border: none;
+    background: none !important;
 }
-.header .search-form .form-control, .header .search-form .swal2-modal .swal2-input, .swal2-modal .header .search-form .swal2-input {
-  border: none;
-  font-size: 16px;
-  background: none;
+
+.header .search-form .form-control,
+.header .search-form .swal2-modal .swal2-input,
+.swal2-modal .header .search-form .swal2-input {
+    border: none;
+    font-size: 16px;
+    background: none;
 }
-.header .search-form .form-control:focus, .header .search-form .swal2-modal .swal2-input:focus, .swal2-modal .header .search-form .swal2-input:focus {
-  border: none;
-  box-shadow: none;
+
+.header .search-form .form-control:focus,
+.header .search-form .swal2-modal .swal2-input:focus,
+.swal2-modal .header .search-form .swal2-input:focus {
+    border: none;
+    box-shadow: none;
 }
-.header .search-form .form-control:focus::-moz-placeholder, .header .search-form .swal2-modal .swal2-input:focus::-moz-placeholder, .swal2-modal .header .search-form .swal2-input:focus::-moz-placeholder {
-  color: black;
+
+.header .search-form .form-control:focus::-moz-placeholder,
+.header .search-form .swal2-modal .swal2-input:focus::-moz-placeholder,
+.swal2-modal .header .search-form .swal2-input:focus::-moz-placeholder {
+    color: black;
 }
-.header .search-form .form-control:focus::placeholder, .header .search-form .swal2-modal .swal2-input:focus::placeholder, .swal2-modal .header .search-form .swal2-input:focus::placeholder {
-  color: black;
+
+.header .search-form .form-control:focus::placeholder,
+.header .search-form .swal2-modal .swal2-input:focus::placeholder,
+.swal2-modal .header .search-form .swal2-input:focus::placeholder {
+    color: black;
 }
+
 .header .search-form .close-header-search-bar {
-  display: none;
+    display: none;
 }
+
 .header .dropdown-menu {
-  position: absolute;
+    position: absolute;
 }
+
 .header .dropdown-menu-lg {
-  min-width: 20rem;
+    min-width: 20rem;
 }
+
 .header .dropdown-menu-body {
-  max-height: 300px;
-  overflow: auto;
+    max-height: 300px;
+    overflow: auto;
 }
+
 .header .header-mobile-buttons {
-  display: flex;
+    display: flex;
 }
+
 .header .header-mobile-buttons a {
-  display: none;
-  align-items: center;
-  font-size: 25px;
-  color: rgba(0, 0, 0, 0.8);
-  padding: 0 10px;
+    display: none;
+    align-items: center;
+    font-size: 25px;
+    color: rgba(0, 0, 0, 0.8);
+    padding: 0 10px;
 }
+
 .header .menu-toggle-btn {
-  margin-right: 15px;
-  margin-top: 5px;
-  display: none;
+    margin-right: 15px;
+    margin-top: 5px;
+    display: none;
 }
+
 .header .menu-toggle-btn a {
-  display: block;
-  font-size: 30px;
-  color: rgba(0, 0, 0, 0.8);
+    display: block;
+    font-size: 30px;
+    color: rgba(0, 0, 0, 0.8);
 }
+
 .header .menu-toggle-btn a:hover {
-  color: #5149e5;
+    color: #5149e5;
 }
+
 .header ul.navbar-nav {
-  flex-direction: row;
-  align-items: center;
+    flex-direction: row;
+    align-items: center;
 }
+
 .header ul.navbar-nav li.nav-item a.nav-link {
-  padding: 0 18px;
-  transition: all 0.2s;
-  color: rgba(0, 0, 0, 0.85);
-  height: 90px;
-  display: flex;
-  align-items: center;
+    padding: 0 18px;
+    transition: all 0.2s;
+    color: rgba(0, 0, 0, 0.85);
+    height: 90px;
+    display: flex;
+    align-items: center;
 }
+
 .header ul.navbar-nav li.nav-item a.nav-link.mobile-header-search-btn {
-  display: none;
+    display: none;
 }
+
 .header ul.navbar-nav li.nav-item a.nav-link.nav-link-notify {
-  position: relative;
+    position: relative;
 }
+
 .header ul.navbar-nav li.nav-item a.nav-link.nav-link-notify:before {
-  content: attr(data-count);
-  position: absolute;
-  width: 19px;
-  height: 19px;
-  display: flex;
-  color: white;
-  font-size: 10px;
-  align-items: center;
-  justify-content: center;
-  right: 50%;
-  border-radius: 50%;
-  margin-right: -10px;
-  transform: translateX(50%);
-  top: 22px;
-  background-color: #ea4444;
+    content: attr(data-count);
+    position: absolute;
+    width: 19px;
+    height: 19px;
+    display: flex;
+    color: white;
+    font-size: 10px;
+    align-items: center;
+    justify-content: center;
+    right: 50%;
+    border-radius: 50%;
+    margin-right: -10px;
+    transform: translateX(50%);
+    top: 22px;
+    background-color: #ea4444;
 }
+
 .header ul.navbar-nav li.nav-item a.nav-link:hover {
-  outline: none;
-  color: #5149e5;
+    outline: none;
+    color: #5149e5;
 }
+
 .header ul.navbar-nav li.nav-item:last-child a.nav-link {
-  padding-right: 0;
+    padding-right: 0;
 }
+
 .header .header-menu .header-menu-header {
-  display: none;
-  justify-content: space-between;
-  align-items: center;
-  height: 90px;
+    display: none;
+    justify-content: space-between;
+    align-items: center;
+    height: 90px;
 }
+
 .header .header-menu .header-menu-header .header-menu-close {
-  background-color: white;
-  border-radius: 0.5rem;
-  font-size: 25px;
+    background-color: white;
+    border-radius: 0.5rem;
+    font-size: 25px;
 }
+
 .header .header-menu .dropdown {
-  display: none;
-  background-color: #f5f4fe;
-  padding: 15px;
-  border-radius: 0.5rem;
-  margin-bottom: 15px;
+    display: none;
+    background-color: #f5f4fe;
+    padding: 15px;
+    border-radius: 0.5rem;
+    margin-bottom: 15px;
 }
+
 .header .header-menu ul.navbar-nav {
-  margin-left: -15px;
+    margin-left: -15px;
 }
+
 .header .header-menu ul.navbar-nav li a {
-  margin-left: 0 !important;
-  background: none !important;
+    margin-left: 0 !important;
+    background: none !important;
 }
+
 .header .header-menu ul.navbar-nav li a i:not(.sub-menu-arrow) {
-  margin-right: 0.7rem;
-  font-size: 18px;
+    margin-right: 0.7rem;
+    font-size: 18px;
 }
+
 .header .header-menu ul.navbar-nav li a .sub-menu-arrow {
-  opacity: 0.7;
-  font-size: 12px;
-  margin-left: auto;
+    opacity: 0.7;
+    font-size: 12px;
+    margin-left: auto;
 }
+
 .header .header-menu ul.navbar-nav li .nav-sub-menu {
-  position: absolute;
-  left: 0;
-  top: 90px;
-  margin-top: -1px;
-  width: 200px;
-  transform-origin: center;
-  display: none;
+    position: absolute;
+    left: 0;
+    top: 90px;
+    margin-top: -1px;
+    width: 200px;
+    transform-origin: center;
+    display: none;
 }
-.header .header-menu ul.navbar-nav li .nav-sub-menu > ul {
-  padding: 15px 0;
-  background: white;
-  display: block;
-  position: relative;
-  border-radius: 0.5rem;
-  box-shadow: 0 0 50px 0 rgba(82, 63, 105, 0.15);
+
+.header .header-menu ul.navbar-nav li .nav-sub-menu>ul {
+    padding: 15px 0;
+    background: white;
+    display: block;
+    position: relative;
+    border-radius: 0.5rem;
+    box-shadow: 0 0 50px 0 rgba(82, 63, 105, 0.15);
 }
-.header .header-menu ul.navbar-nav li .nav-sub-menu > ul li {
-  position: relative;
-  list-style-type: none;
+
+.header .header-menu ul.navbar-nav li .nav-sub-menu>ul li {
+    position: relative;
+    list-style-type: none;
 }
-.header .header-menu ul.navbar-nav li .nav-sub-menu > ul li a {
-  color: black;
-  transition: all 0.2s;
-  padding: 10px 25px;
-  display: flex;
-  align-items: center;
+
+.header .header-menu ul.navbar-nav li .nav-sub-menu>ul li a {
+    color: black;
+    transition: all 0.2s;
+    padding: 10px 25px;
+    display: flex;
+    align-items: center;
 }
-.header .header-menu ul.navbar-nav li .nav-sub-menu > ul li a.active {
-  color: #5149e5;
+
+.header .header-menu ul.navbar-nav li .nav-sub-menu>ul li a.active {
+    color: #5149e5;
 }
-.header .header-menu ul.navbar-nav li .nav-sub-menu > ul li a .sub-menu-arrow {
-  margin-left: auto;
+
+.header .header-menu ul.navbar-nav li .nav-sub-menu>ul li a .sub-menu-arrow {
+    margin-left: auto;
 }
-.header .header-menu ul.navbar-nav li .nav-sub-menu > ul li:hover > a {
-  color: #5149e5;
+
+.header .header-menu ul.navbar-nav li .nav-sub-menu>ul li:hover>a {
+    color: #5149e5;
 }
+
 .header .header-menu ul.navbar-nav li .nav-sub-menu .nav-sub-menu {
-  left: 200px;
-  top: -15px;
-  padding-left: 15px;
-  margin-left: -1px;
-  width: 215px;
+    left: 200px;
+    top: -15px;
+    padding-left: 15px;
+    margin-left: -1px;
+    width: 215px;
 }
+
 .header .header-menu ul.navbar-nav li .nav-sub-menu .nav-sub-menu .navbar-nav {
-  position: relative;
-  border-radius: 0.5rem;
+    position: relative;
+    border-radius: 0.5rem;
 }
-.header .header-menu ul.navbar-nav li:hover > .nav-sub-menu {
-  display: block;
+
+.header .header-menu ul.navbar-nav li:hover>.nav-sub-menu {
+    display: block;
 }
+
 .header .header-menu ul.navbar-nav li:hover a {
-  background: rgba(255, 255, 255, 0.15);
+    background: rgba(255, 255, 255, 0.15);
 }
-.header .header-menu ul.navbar-nav > li {
-  position: relative;
+
+.header .header-menu ul.navbar-nav>li {
+    position: relative;
 }
-.header .header-menu ul.navbar-nav > li > a.active {
-  color: #5149e5;
+
+.header .header-menu ul.navbar-nav>li>a.active {
+    color: #5149e5;
 }
-.header .header-menu ul.navbar-nav > li > a .sub-menu-arrow {
-  margin-left: 10px;
-  transform: rotate(90deg);
+
+.header .header-menu ul.navbar-nav>li>a .sub-menu-arrow {
+    margin-left: 10px;
+    transform: rotate(90deg);
 }
-.header .header-menu ul.navbar-nav > li.open > a {
-  color: #5149e5;
+
+.header .header-menu ul.navbar-nav>li.open>a {
+    color: #5149e5;
 }
-.header .header-menu ul.navbar-nav > li.open .open > a {
-  color: #5149e5 !important;
+
+.header .header-menu ul.navbar-nav>li.open .open>a {
+    color: #5149e5 !important;
 }
 
 .preloader {
-  position: fixed;
-  right: 0;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  z-index: 9999;
-  background-color: white;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 15px;
-}
-.preloader img {
-  width: 100px;
-}
-.preloader span {
-  text-transform: uppercase;
-  font-size: 12px;
-  letter-spacing: 2px;
-  margin-top: 15px;
-}
-.preloader .preloader-icon {
-  border: 5px solid white;
-  border-radius: 50%;
-  border-top: 5px solid #5149e5;
-  width: 50px;
-  height: 50px;
-  margin-left: 10px;
-  animation: spin 0.3s linear infinite;
-}
-@keyframes spin {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-}
-.preloader svg path {
-  fill: #5149e5;
+    position: fixed;
+    right: 0;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    z-index: 9999;
+    background-color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 15px;
 }
 
-.wizard > .content {
-  min-height: auto !important;
-  min-width: auto !important;
-  margin: 0 !important;
-  margin-bottom: 15px !important;
-  background: none;
-  padding: 0 !important;
+.preloader img {
+    width: 100px;
+}
+
+.preloader span {
+    text-transform: uppercase;
+    font-size: 12px;
+    letter-spacing: 2px;
+    margin-top: 15px;
+}
+
+.preloader .preloader-icon {
+    border: 5px solid white;
+    border-radius: 50%;
+    border-top: 5px solid #5149e5;
+    width: 50px;
+    height: 50px;
+    margin-left: 10px;
+    animation: spin 0.3s linear infinite;
+}
+
+@keyframes spin {
+    0% {
+        transform: rotate(0deg);
+    }
+
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+.preloader svg path {
+    fill: #5149e5;
+}
+
+.wizard>.content {
+    min-height: auto !important;
+    min-width: auto !important;
+    margin: 0 !important;
+    margin-bottom: 15px !important;
+    background: none;
+    padding: 0 !important;
 }
 
 .wizard .wizard-index {
-  background-color: rgba(0, 0, 0, 0.4);
-  height: 30px;
-  width: 30px;
-  border-radius: 50%;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  color: #fff;
-  margin-right: 0.5rem;
-}
-.wizard .current .wizard-index, .wizard .done .wizard-index {
-  background-color: rgba(255, 255, 255, 0.2);
+    background-color: rgba(0, 0, 0, 0.4);
+    height: 30px;
+    width: 30px;
+    border-radius: 50%;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    color: #fff;
+    margin-right: 0.5rem;
 }
 
-.wizard > .actions > ul > li {
-  margin: 0;
-  margin-left: 10px;
+.wizard .current .wizard-index,
+.wizard .done .wizard-index {
+    background-color: rgba(255, 255, 255, 0.2);
 }
 
-.wizard > .content > .body {
-  float: none;
-  position: static;
-  width: auto;
-  height: auto;
+.wizard>.actions>ul>li {
+    margin: 0;
+    margin-left: 10px;
 }
 
-.wizard > .steps {
-  margin-bottom: 1.5rem;
-}
-.wizard > .steps a:hover {
-  display: flex;
-}
-.wizard > .steps > ul > li {
-  width: auto;
+.wizard>.content>.body {
+    float: none;
+    position: static;
+    width: auto;
+    height: auto;
 }
 
-.wizard > .steps a {
-  display: flex;
-  align-items: center;
+.wizard>.steps {
+    margin-bottom: 1.5rem;
 }
 
-.wizard > .steps a, .wizard > .steps a:hover, .wizard > .steps a:active {
-  margin: 0;
-  margin-right: 10px;
+.wizard>.steps a:hover {
+    display: flex;
 }
 
-.wizard > .steps .current a, .wizard > .steps .current a:hover, .wizard > .steps .current a:active {
-  background: #5149e5;
-  color: white !important;
+.wizard>.steps>ul>li {
+    width: auto;
 }
 
-.wizard > .steps .error a, .wizard > .steps .error a:hover, .wizard > .steps .error a:active {
-  background: #ea4444;
+.wizard>.steps a {
+    display: flex;
+    align-items: center;
 }
 
-.wizard > .steps .done a, .wizard > .steps .done a:hover, .wizard > .steps .done a:active {
-  background-color: #05b171;
-  color: white !important;
+.wizard>.steps a,
+.wizard>.steps a:hover,
+.wizard>.steps a:active {
+    margin: 0;
+    margin-right: 10px;
 }
 
-.wizard > .actions a, .wizard > .actions a:hover, .wizard > .actions a:active {
-  background-color: #05b171;
-  color: white;
+.wizard>.steps .current a,
+.wizard>.steps .current a:hover,
+.wizard>.steps .current a:active {
+    background: #5149e5;
+    color: white !important;
+}
+
+.wizard>.steps .error a,
+.wizard>.steps .error a:hover,
+.wizard>.steps .error a:active {
+    background: #ea4444;
+}
+
+.wizard>.steps .done a,
+.wizard>.steps .done a:hover,
+.wizard>.steps .done a:active {
+    background-color: #05b171;
+    color: white !important;
+}
+
+.wizard>.actions a,
+.wizard>.actions a:hover,
+.wizard>.actions a:active {
+    background-color: #05b171;
+    color: white;
 }
 
 .mfp-with-zoom .mfp-container,
 .mfp-with-zoom.mfp-bg {
-  opacity: 0;
-  -webkit-backface-visibility: hidden;
-  /* ideally, transition speed should match zoom duration */
-  transition: all 0.3s ease-out;
+    opacity: 0;
+    -webkit-backface-visibility: hidden;
+    /* ideally, transition speed should match zoom duration */
+    transition: all 0.3s ease-out;
 }
 
 .mfp-with-zoom.mfp-ready .mfp-container {
-  opacity: 1;
+    opacity: 1;
 }
 
 .mfp-with-zoom.mfp-ready.mfp-bg {
-  opacity: 0.8;
+    opacity: 0.8;
 }
 
 .mfp-with-zoom.mfp-removing .mfp-container,
 .mfp-with-zoom.mfp-removing.mfp-bg {
-  opacity: 0;
+    opacity: 0;
 }
 
 .card {
-  border: none;
-  transition: transform 0.3s;
-}
-.card.card-hover:hover {
-  transform: scale(1.01);
-}
-.card.card-selected {
-  box-shadow: 0 0 0 2px #5149e5;
-  transform: scale(1.02);
-}
-.card .card-title {
-  font-size: 1.2rem;
-}
-.card .card {
-  border: var(--bs-border-width) solid var(--bs-border-color-translucent);
-}
-.card .card-header, .card .card-footer {
-  background: none;
-}
-.card.widget {
-  background: none;
-}
-.card.widget .card-header {
-  background-color: #f5f4fe;
-  border-bottom: 0;
-  padding-left: 0;
-  padding-right: 0;
-  padding-top: 0;
-  height: 50px;
-}
-.card.widget .card-header + .card-body {
-  background-color: white;
-  border-radius: 1rem;
+    border: none;
+    transition: transform 0.3s;
 }
 
-.bd-example > .dropdown-menu {
-  height: auto;
-  position: static;
-  opacity: 1;
-  visibility: visible;
-  box-shadow: none !important;
-  border: 1px solid rgba(0, 0, 0, 0.15);
+.card.card-hover:hover {
+    transform: scale(1.01);
+}
+
+.card.card-selected {
+    box-shadow: 0 0 0 2px #5149e5;
+    transform: scale(1.02);
+}
+
+.card .card-title {
+    font-size: 1.2rem;
+}
+
+.card .card {
+    border: var(--bs-border-width) solid var(--bs-border-color-translucent);
+}
+
+.card .card-header,
+.card .card-footer {
+    background: none;
+}
+
+.card.widget {
+    background: none;
+}
+
+.card.widget .card-header {
+    background-color: #f5f4fe;
+    border-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+    height: 50px;
+}
+
+.card.widget .card-header+.card-body {
+    background-color: white;
+    border-radius: 1rem;
+}
+
+.bd-example>.dropdown-menu {
+    height: auto;
+    position: static;
+    opacity: 1;
+    visibility: visible;
+    box-shadow: none !important;
+    border: 1px solid rgba(0, 0, 0, 0.15);
 }
 
 .dropdown {
-  display: inline;
+    display: inline;
 }
 
 .dropdown-item-icon {
-  margin-right: 0.7rem;
-  width: 15px;
+    margin-right: 0.7rem;
+    width: 15px;
 }
 
 .dropdown-header {
-  font-size: inherit;
-  padding: 10px 20px;
-  border-bottom: 1px solid #f0f0f0;
+    font-size: inherit;
+    padding: 10px 20px;
+    border-bottom: 1px solid #f0f0f0;
 }
 
 .dropdown-body {
-  padding: 10px 20px;
+    padding: 10px 20px;
 }
 
 .dropdown-menu {
-  margin-top: 10px;
-  visibility: hidden;
-  opacity: 0;
-  height: 0;
-  min-width: 13rem;
-  transition: margin-top 0.2s, opacity 0.2s;
-  border: none;
-  box-shadow: 0 0 50px 0 rgba(82, 63, 105, 0.15) !important;
+    margin-top: 10px;
+    visibility: hidden;
+    opacity: 0;
+    height: 0;
+    min-width: 13rem;
+    transition: margin-top 0.2s, opacity 0.2s;
+    border: none;
+    box-shadow: 0 0 50px 0 rgba(82, 63, 105, 0.15) !important;
 }
+
 .dropdown-menu .dropdown-scroll {
-  max-height: 300px;
+    max-height: 300px;
 }
+
 .dropdown-menu.show {
-  margin-top: 0;
-  visibility: visible;
-  opacity: 1;
-  height: auto;
+    margin-top: 0;
+    visibility: visible;
+    opacity: 1;
+    height: auto;
 }
+
 .dropdown-menu.dropdown-menu-big {
-  padding: 0;
-  width: 330px;
+    padding: 0;
+    width: 330px;
 }
+
 .dropdown-menu .dropdown-menu-body {
-  max-height: 400px;
-  overflow: auto;
+    max-height: 400px;
+    overflow: auto;
 }
+
 .dropdown-menu .dropdown-menu-title {
-  background-color: #5149e5;
-  padding: 15px 20px;
-  color: white;
-  background-size: cover !important;
-  background-position: center !important;
+    background-color: #5149e5;
+    padding: 15px 20px;
+    color: white;
+    background-size: cover !important;
+    background-position: center !important;
 }
+
 .dropdown-menu .dropdown-menu-footer {
-  padding: 10px 20px;
+    padding: 10px 20px;
 }
+
 .dropdown-menu ul li.dropdown-menu-title {
-  background: red;
-  margin: 5px 0;
-  padding: 0px 20px 5px;
-  border-bottom: 1px solid #ebebeb;
+    background: red;
+    margin: 5px 0;
+    padding: 0px 20px 5px;
+    border-bottom: 1px solid #ebebeb;
 }
+
 .dropdown-menu ul li.dropdown-menu-title:first-child {
-  margin-top: 0;
+    margin-top: 0;
 }
+
 .dropdown-menu .dropdown-item {
-  padding: 8px 25px;
+    padding: 8px 25px;
 }
-.dropdown-menu .dropdown-item:hover, .dropdown-menu .dropdown-item:focus, .dropdown-menu .dropdown-item:active {
-  background: none;
-  text-decoration: none;
-  color: #5149e5;
+
+.dropdown-menu .dropdown-item:hover,
+.dropdown-menu .dropdown-item:focus,
+.dropdown-menu .dropdown-item:active {
+    background: none;
+    text-decoration: none;
+    color: #5149e5;
 }
 
 .daterangepicker {
-  border-color: #e6e6e6;
-  border-radius: 0.5rem;
-  overflow: hidden;
+    border-color: #e6e6e6;
+    border-radius: 0.5rem;
+    overflow: hidden;
 }
+
 .daterangepicker td.active {
-  background: #5149e5;
+    background: #5149e5;
 }
+
 .daterangepicker td.active:hover {
-  background: #5149e5;
+    background: #5149e5;
 }
+
 .daterangepicker .ranges li.active {
-  background: #5149e5;
+    background: #5149e5;
 }
+
 .daterangepicker.show-ranges .drp-calendar.left {
-  border-left-color: #e6e6e6;
+    border-left-color: #e6e6e6;
 }
+
 .daterangepicker .drp-buttons {
-  border-top-color: #e6e6e6;
+    border-top-color: #e6e6e6;
 }
 
 .tourStep {
-  border: none;
+    border: none;
 }
+
 .tourStep.right {
-  margin-left: 10px;
+    margin-left: 10px;
 }
+
 .tourStep.left {
-  margin-right: 10px;
+    margin-right: 10px;
 }
+
 .tourStep.top {
-  margin-top: -10px;
+    margin-top: -10px;
 }
+
 .tourStep.bottom {
-  margin-top: 10px;
+    margin-top: 10px;
 }
+
 .tourStep .popover-navigation {
-  border-top: 1px solid #ddd;
-  padding: 0.5rem 0.75rem;
-  display: flex;
-  align-items: center;
+    border-top: 1px solid #ddd;
+    padding: 0.5rem 0.75rem;
+    display: flex;
+    align-items: center;
 }
+
 .tourStep .popover-navigation span {
-  color: #9b9b9b;
+    color: #9b9b9b;
 }
+
 .tourStep .popover-navigation .popover-navigation-buttons {
-  margin-left: auto;
+    margin-left: auto;
 }
+
 .tourStep .popover-navigation .popover-navigation-buttons .btn {
-  margin-left: 5px;
+    margin-left: 5px;
 }
 
 .swal2-modal {
-  border-radius: 0.5rem;
-}
-.swal2-modal .swal2-title {
-  font-size: 22px;
-}
-.swal2-modal .swal2-text {
-  text-align: center;
-}
-.swal2-modal .swal2-actions button {
-  border-radius: 0.5rem;
-  padding: 0.375rem 0.75rem;
-}
-.swal2-modal .swal2-actions .swal2-confirm {
-  background: #5149e5;
-  color: #fff;
-}
-.swal2-modal .swal2-actions .swal2-deny {
-  background: #ededed;
-  color: #000;
-}
-.swal2-modal .swal2-actions .swal2-cancel {
-  background: #ea4444;
-  color: #fff;
-}
-.swal2-modal .swal2-icon.swal2-error {
-  border-color: #ea4444;
-}
-.swal2-modal .swal2-icon.swal2-error .swal2-x-mark-line-left, .swal2-modal .swal2-icon.swal2-error .swal2-x-mark-line-right {
-  background: #ea4444;
-}
-.swal2-modal .swal2-icon.swal2-success .swal2-success-ring {
-  border-color: #05b171;
-}
-.swal2-modal .swal2-icon.swal2-success [class^=swal2-success-line] {
-  background: #05b171;
-}
-.swal2-modal .swal2-icon.swal2-warning {
-  border-color: #faae42;
-  color: #faae42;
-}
-.swal2-modal .swal2-icon.swal2-info {
-  border-color: #25c2e3;
-  color: #25c2e3;
-}
-.swal2-progress-steps .swal2-progress-step.swal2-active-progress-step {
-  background: #5149e5;
-}
-.swal2-progress-steps .swal2-progress-step.swal2-active-progress-step ~ .swal2-progress-step {
-  background: rgba(81, 73, 229, 0.3);
+    border-radius: 0.5rem;
 }
 
-.irs .irs-single, .irs .irs-to, .irs .irs-from {
-  background: #5149e5;
+.swal2-modal .swal2-title {
+    font-size: 22px;
 }
-.irs .irs-single:before, .irs .irs-to:before, .irs .irs-from:before {
-  border-top-color: #5149e5;
+
+.swal2-modal .swal2-text {
+    text-align: center;
 }
+
+.swal2-modal .swal2-actions button {
+    border-radius: 0.5rem;
+    padding: 0.375rem 0.75rem;
+}
+
+.swal2-modal .swal2-actions .swal2-confirm {
+    background: #5149e5;
+    color: #fff;
+}
+
+.swal2-modal .swal2-actions .swal2-deny {
+    background: #ededed;
+    color: #000;
+}
+
+.swal2-modal .swal2-actions .swal2-cancel {
+    background: #ea4444;
+    color: #fff;
+}
+
+.swal2-modal .swal2-icon.swal2-error {
+    border-color: #ea4444;
+}
+
+.swal2-modal .swal2-icon.swal2-error .swal2-x-mark-line-left,
+.swal2-modal .swal2-icon.swal2-error .swal2-x-mark-line-right {
+    background: #ea4444;
+}
+
+.swal2-modal .swal2-icon.swal2-success .swal2-success-ring {
+    border-color: #05b171;
+}
+
+.swal2-modal .swal2-icon.swal2-success [class^=swal2-success-line] {
+    background: #05b171;
+}
+
+.swal2-modal .swal2-icon.swal2-warning {
+    border-color: #faae42;
+    color: #faae42;
+}
+
+.swal2-modal .swal2-icon.swal2-info {
+    border-color: #25c2e3;
+    color: #25c2e3;
+}
+
+.swal2-progress-steps .swal2-progress-step.swal2-active-progress-step {
+    background: #5149e5;
+}
+
+.swal2-progress-steps .swal2-progress-step.swal2-active-progress-step~.swal2-progress-step {
+    background: rgba(81, 73, 229, 0.3);
+}
+
+.irs .irs-single,
+.irs .irs-to,
+.irs .irs-from {
+    background: #5149e5;
+}
+
+.irs .irs-single:before,
+.irs .irs-to:before,
+.irs .irs-from:before {
+    border-top-color: #5149e5;
+}
+
 .irs .irs-handle {
-  border-color: #5149e5;
+    border-color: #5149e5;
 }
+
 .irs .irs-bar {
-  background: #5149e5;
+    background: #5149e5;
 }
 
 .select2 {
-  width: 100% !important;
+    width: 100% !important;
 }
 
 .select2-results__option {
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
 }
 
 .select2-search--dropdown {
-  padding: 0.75rem;
+    padding: 0.75rem;
 }
+
 .select2-search--dropdown .select2-search__field {
-  border-radius: 0.5rem;
-  height: calc(1.5em + 0.75rem + 3px);
-  padding: 0 0.75rem;
+    border-radius: 0.5rem;
+    height: calc(1.5em + 0.75rem + 3px);
+    padding: 0 0.75rem;
 }
+
 .select2-search--dropdown .select2-search__field:focus {
-  box-shadow: 0 0 0 1px #5149e5;
-  border-color: rgba(81, 73, 229, 0.8) !important;
+    box-shadow: 0 0 0 1px #5149e5;
+    border-color: rgba(81, 73, 229, 0.8) !important;
 }
 
 .select2.select2-container .select2-selection--single {
-  height: calc(1.5em + 0.75rem + 3px);
+    height: calc(1.5em + 0.75rem + 3px);
 }
+
 .select2.select2-container .select2-selection--single .select2-selection__rendered {
-  line-height: calc(1.5em + 0.75rem + 3px);
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
+    line-height: calc(1.5em + 0.75rem + 3px);
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
 }
+
 .select2.select2-container .select2-selection {
-  border: 1px solid #ced4da;
+    border: 1px solid #ced4da;
 }
+
 .select2.select2-container .select2-selection .select2-selection__arrow {
-  height: calc(2.25rem + 2px);
-  width: 30px;
+    height: calc(2.25rem + 2px);
+    width: 30px;
 }
+
 .select2.select2-container .select2-selection .select2-selection__choice {
-  display: flex;
-  align-items: center;
-  border: none;
+    display: flex;
+    align-items: center;
+    border: none;
 }
+
 .select2.select2-container .select2-selection .select2-selection__choice .select2-selection__choice__remove {
-  font-size: 16px;
-  padding: 0 5px 0 3px;
+    font-size: 16px;
+    padding: 0 5px 0 3px;
 }
+
 .select2.select2-container .select2-selection.select2-container--focus {
-  border-color: red;
+    border-color: red;
 }
 
 .select2-container--default .select2-results__option--highlighted[aria-selected] {
-  background-color: #5149e5;
-  color: white;
+    background-color: #5149e5;
+    color: white;
 }
 
 .select2-container--default.select2-container--focus .select2-selection--multiple {
-  box-shadow: 0 0 0 1px #5149e5;
-  border-color: rgba(81, 73, 229, 0.8) !important;
+    box-shadow: 0 0 0 1px #5149e5;
+    border-color: rgba(81, 73, 229, 0.8) !important;
 }
 
 .select2-container--default .select2-search--dropdown .select2-search__field {
-  height: calc(2.25rem + 2px);
-  padding: 0.375rem 0.75rem;
+    height: calc(2.25rem + 2px);
+    padding: 0.375rem 0.75rem;
 }
 
 a.avatar {
-  display: inline-block;
-  color: black;
+    display: inline-block;
+    color: black;
 }
+
 a.avatar:hover {
-  opacity: 0.9;
+    opacity: 0.9;
 }
 
 .avatar {
-  display: inline-block;
-  margin-bottom: 0;
-  height: 3rem;
-  width: 3rem;
-  border-radius: 50%;
+    display: inline-block;
+    margin-bottom: 0;
+    height: 3rem;
+    width: 3rem;
+    border-radius: 50%;
 }
+
 .avatar .avatar-text {
-  background: #d7d7d7;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-transform: uppercase;
-  font-size: 20px;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-          user-select: none;
+    background: #d7d7d7;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-transform: uppercase;
+    font-size: 20px;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    user-select: none;
 }
+
 .avatar .avatar-text i {
-  line-height: 20px;
+    line-height: 20px;
 }
+
 .avatar.avatar-primary .avatar-text {
-  background: #5149e5 !important;
-  color: #fff !important;
+    background: #5149e5 !important;
+    color: #fff !important;
 }
+
 .avatar.avatar-secondary .avatar-text {
-  background: #9932e7 !important;
-  color: #fff !important;
+    background: #9932e7 !important;
+    color: #fff !important;
 }
+
 .avatar.avatar-success .avatar-text {
-  background: #05b171 !important;
-  color: #fff;
+    background: #05b171 !important;
+    color: #fff;
 }
+
 .avatar.avatar-danger .avatar-text {
-  background: #ea4444 !important;
-  color: #fff !important;
+    background: #ea4444 !important;
+    color: #fff !important;
 }
+
 .avatar.avatar-warning .avatar-text {
-  background: #faae42 !important;
-  color: #000 !important;
+    background: #faae42 !important;
+    color: #000 !important;
 }
+
 .avatar.avatar-info .avatar-text {
-  background: #25c2e3 !important;
-  color: #fff !important;
+    background: #25c2e3 !important;
+    color: #fff !important;
 }
+
 .avatar.avatar-light .avatar-text {
-  background: #ededed !important;
-  color: #000 !important;
+    background: #ededed !important;
+    color: #000 !important;
 }
+
 .avatar.avatar-dark .avatar-text {
-  background: #293134 !important;
-  color: #fff !important;
+    background: #293134 !important;
+    color: #fff !important;
 }
-.avatar > img {
-  width: 100%;
-  height: 100%;
-  -o-object-fit: cover;
-     object-fit: cover;
+
+.avatar>img {
+    width: 100%;
+    height: 100%;
+    -o-object-fit: cover;
+    object-fit: cover;
 }
+
 .avatar.avatar-sm {
-  height: 2.2rem;
-  width: 2.2rem;
+    height: 2.2rem;
+    width: 2.2rem;
 }
+
 .avatar.avatar-sm .avatar-text {
-  font-size: 14px;
+    font-size: 14px;
 }
+
 .avatar.avatar-sm .avatar-text i {
-  line-height: 12px;
+    line-height: 12px;
 }
-.avatar.avatar-sm.avatar-state-primary:before, .avatar.avatar-sm.avatar-state-success:before, .avatar.avatar-sm.avatar-state-danger:before, .avatar.avatar-sm.avatar-state-warning:before, .avatar.avatar-sm.avatar-state-info:before, .avatar.avatar-sm.avatar-state-secondary:before, .avatar.avatar-sm.avatar-state-light:before, .avatar.avatar-sm.avatar-state-dark:before {
-  width: 0.6666666667rem;
-  height: 0.6666666667rem;
+
+.avatar.avatar-sm.avatar-state-primary:before,
+.avatar.avatar-sm.avatar-state-success:before,
+.avatar.avatar-sm.avatar-state-danger:before,
+.avatar.avatar-sm.avatar-state-warning:before,
+.avatar.avatar-sm.avatar-state-info:before,
+.avatar.avatar-sm.avatar-state-secondary:before,
+.avatar.avatar-sm.avatar-state-light:before,
+.avatar.avatar-sm.avatar-state-dark:before {
+    width: 0.6666666667rem;
+    height: 0.6666666667rem;
 }
+
 .avatar.avatar-lg {
-  height: 4.5rem;
-  width: 4.5rem;
+    height: 4.5rem;
+    width: 4.5rem;
 }
+
 .avatar.avatar-lg .avatar-text {
-  font-size: 30px;
+    font-size: 30px;
 }
+
 .avatar.avatar-lg .avatar-text i {
-  line-height: 30px;
+    line-height: 30px;
 }
-.avatar.avatar-lg.avatar-state-primary:before, .avatar.avatar-lg.avatar-state-success:before, .avatar.avatar-lg.avatar-state-danger:before, .avatar.avatar-lg.avatar-state-warning:before, .avatar.avatar-lg.avatar-state-info:before, .avatar.avatar-lg.avatar-state-secondary:before, .avatar.avatar-lg.avatar-state-light:before, .avatar.avatar-lg.avatar-state-dark:before {
-  width: 0.88rem;
-  height: 0.88rem;
-  right: 4px;
+
+.avatar.avatar-lg.avatar-state-primary:before,
+.avatar.avatar-lg.avatar-state-success:before,
+.avatar.avatar-lg.avatar-state-danger:before,
+.avatar.avatar-lg.avatar-state-warning:before,
+.avatar.avatar-lg.avatar-state-info:before,
+.avatar.avatar-lg.avatar-state-secondary:before,
+.avatar.avatar-lg.avatar-state-light:before,
+.avatar.avatar-lg.avatar-state-dark:before {
+    width: 0.88rem;
+    height: 0.88rem;
+    right: 4px;
 }
+
 .avatar.avatar-xl {
-  height: 5.8rem;
-  width: 5.8rem;
+    height: 5.8rem;
+    width: 5.8rem;
 }
+
 .avatar.avatar-xl .avatar-text {
-  font-size: 40px;
+    font-size: 40px;
 }
+
 .avatar.avatar-xl .avatar-text i {
-  line-height: 40px;
+    line-height: 40px;
 }
-.avatar.avatar-xl.avatar-state-primary:before, .avatar.avatar-xl.avatar-state-success:before, .avatar.avatar-xl.avatar-state-danger:before, .avatar.avatar-xl.avatar-state-warning:before, .avatar.avatar-xl.avatar-state-info:before, .avatar.avatar-xl.avatar-state-secondary:before, .avatar.avatar-xl.avatar-state-light:before, .avatar.avatar-xl.avatar-state-dark:before {
-  width: 1.04rem;
-  height: 1.04rem;
-  top: 3px;
-  right: 3px;
+
+.avatar.avatar-xl.avatar-state-primary:before,
+.avatar.avatar-xl.avatar-state-success:before,
+.avatar.avatar-xl.avatar-state-danger:before,
+.avatar.avatar-xl.avatar-state-warning:before,
+.avatar.avatar-xl.avatar-state-info:before,
+.avatar.avatar-xl.avatar-state-secondary:before,
+.avatar.avatar-xl.avatar-state-light:before,
+.avatar.avatar-xl.avatar-state-dark:before {
+    width: 1.04rem;
+    height: 1.04rem;
+    top: 3px;
+    right: 3px;
 }
-.avatar.avatar-state-primary, .avatar.avatar-state-success, .avatar.avatar-state-danger, .avatar.avatar-state-warning, .avatar.avatar-state-info, .avatar.avatar-state-secondary, .avatar.avatar-state-light, .avatar.avatar-state-dark {
-  position: relative;
+
+.avatar.avatar-state-primary,
+.avatar.avatar-state-success,
+.avatar.avatar-state-danger,
+.avatar.avatar-state-warning,
+.avatar.avatar-state-info,
+.avatar.avatar-state-secondary,
+.avatar.avatar-state-light,
+.avatar.avatar-state-dark {
+    position: relative;
 }
-.avatar.avatar-state-primary:before, .avatar.avatar-state-success:before, .avatar.avatar-state-danger:before, .avatar.avatar-state-warning:before, .avatar.avatar-state-info:before, .avatar.avatar-state-secondary:before, .avatar.avatar-state-light:before, .avatar.avatar-state-dark:before {
-  content: "";
-  position: absolute;
-  display: block;
-  width: 0.8rem;
-  height: 0.8rem;
-  border-radius: 50%;
-  top: -1px;
-  right: -1px;
-  border: 2px solid white;
-}
-.avatar.avatar-state-primary:before {
-  background: #5149e5;
-}
-.avatar.avatar-state-success:before {
-  background: #05b171;
-}
-.avatar.avatar-state-danger:before {
-  background: #ea4444;
-}
-.avatar.avatar-state-warning:before {
-  background: #faae42;
-}
-.avatar.avatar-state-info:before {
-  background: #25c2e3;
-}
-.avatar.avatar-state-secondary:before {
-  background: #9932e7;
-}
-.avatar.avatar-state-light:before {
-  background: #ededed;
-}
+
+.avatar.avatar-state-primary:before,
+.avatar.avatar-state-success:before,
+.avatar.avatar-state-danger:before,
+.avatar.avatar-state-warning:before,
+.avatar.avatar-state-info:before,
+.avatar.avatar-state-secondary:before,
+.avatar.avatar-state-light:before,
 .avatar.avatar-state-dark:before {
-  background: #293134;
+    content: "";
+    position: absolute;
+    display: block;
+    width: 0.8rem;
+    height: 0.8rem;
+    border-radius: 50%;
+    top: -1px;
+    right: -1px;
+    border: 2px solid white;
+}
+
+.avatar.avatar-state-primary:before {
+    background: #5149e5;
+}
+
+.avatar.avatar-state-success:before {
+    background: #05b171;
+}
+
+.avatar.avatar-state-danger:before {
+    background: #ea4444;
+}
+
+.avatar.avatar-state-warning:before {
+    background: #faae42;
+}
+
+.avatar.avatar-state-info:before {
+    background: #25c2e3;
+}
+
+.avatar.avatar-state-secondary:before {
+    background: #9932e7;
+}
+
+.avatar.avatar-state-light:before {
+    background: #ededed;
+}
+
+.avatar.avatar-state-dark:before {
+    background: #293134;
 }
 
 .avatar-group {
-  display: inline-flex;
-}
-.avatar-group .avatar {
-  margin-right: -1rem;
-  border: 3px solid white;
-}
-.avatar-group .avatar:last-child {
-  margin-right: 0;
-}
-.avatar-group .avatar:hover {
-  position: relative;
-  z-index: 1;
+    display: inline-flex;
 }
 
+.avatar-group .avatar {
+    margin-right: -1rem;
+    border: 3px solid white;
+}
+
+.avatar-group .avatar:last-child {
+    margin-right: 0;
+}
+
+.avatar-group .avatar:hover {
+    position: relative;
+    z-index: 1;
+}
+
+
 .dropzone {
-  border-width: 1px;
-  border-color: #5149e5;
+    border-width: 1px;
+    border-color: #5149e5;
 }
 
 .auth {
-  background-color: #5149e5;
+    background-color: #5149e5;
 }
+
 .auth .form-wrapper {
-  display: flex;
-  align-items: center;
-  min-height: 100%;
-  padding: 30px 15px;
+    display: flex;
+    align-items: center;
+    min-height: 100%;
+    padding: 30px 15px;
 }
-.auth .form-wrapper .container, .auth .form-wrapper .container-fluid, .auth .form-wrapper .container-sm, .auth .form-wrapper .container-md, .auth .form-wrapper .container-lg, .auth .form-wrapper .container-xl, .auth .form-wrapper .container-xxl {
-  min-height: 100%;
+
+.auth .form-wrapper .container,
+.auth .form-wrapper .container-fluid,
+.auth .form-wrapper .container-sm,
+.auth .form-wrapper .container-md,
+.auth .form-wrapper .container-lg,
+.auth .form-wrapper .container-xl,
+.auth .form-wrapper .container-xxl {
+    min-height: 100%;
 }
+
 @media (min-width: 1200px) {
-  .auth .form-wrapper {
-    width: 1000px;
-    margin: auto;
-  }
+    .auth .form-wrapper {
+        width: 1000px;
+        margin: auto;
+    }
 }
+
 .auth .card {
-  border: none;
-  margin: auto;
-  border-radius: 0.5rem;
-  overflow: hidden;
+    border: none;
+    margin: auto;
+    border-radius: 0.5rem;
+    overflow: hidden;
 }
+
 .auth .card .row .col {
-  padding: 30px;
-  min-height: 500px;
+    padding: 30px;
+    min-height: 500px;
 }
+
 .auth .social-links {
-  display: block;
+    display: block;
 }
+
 .auth .social-links a {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  transition: all 0.3s;
-  color: black;
-  margin-bottom: 15px;
-  border-radius: 10px;
-  border: 1px solid #cccccc;
-  padding: 2px;
-  padding-right: 20px;
+    flex: 1;
+    display: flex;
+    align-items: center;
+    transition: all 0.3s;
+    color: black;
+    margin-bottom: 15px;
+    border-radius: 10px;
+    border: 1px solid #cccccc;
+    padding: 2px;
+    padding-right: 20px;
 }
+
 .auth .social-links a i {
-  width: 40px;
-  font-size: 20px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: white;
-  height: 40px;
-  border-radius: 10px;
-  margin-right: 15px;
+    width: 40px;
+    font-size: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    height: 40px;
+    border-radius: 10px;
+    margin-right: 15px;
 }
-.auth .social-links a:hover, .auth .social-links a:focus {
-  text-decoration: none;
-  border-color: #4776E6;
+
+.auth .social-links a:hover,
+.auth .social-links a:focus {
+    text-decoration: none;
+    border-color: #4776E6;
 }
 
 [data-close-chat] {
-  display: none;
+    display: none;
 }
 
 @media (max-width: 992px) {
-  [data-close-chat].show {
-    display: block;
-  }
-  [data-close-chat].hide {
-    display: none;
-  }
+    [data-close-chat].show {
+        display: block;
+    }
+
+    [data-close-chat].hide {
+        display: none;
+    }
 }
+
 .chat-block {
-  height: calc(100vh - (90px + 3rem + 52px));
-  display: flex;
+    height: calc(100vh - (90px + 3rem + 52px));
+    display: flex;
 }
+
 .chat-block .chat-sidebar {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  width: 400px;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    width: 400px;
 }
+
 .chat-block .chat-sidebar .chat-sidebar-content {
-  flex: 1;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  overflow: auto;
-  padding: 0 1px;
+    flex: 1;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    overflow: auto;
+    padding: 0 1px;
 }
+
 .chat-block .chat-sidebar .chat-sidebar-content .list-group .list-group-item {
-  border: none;
-  border-radius: 0.5rem;
-  background-color: white;
-  margin-bottom: 15px;
+    border: none;
+    border-radius: 0.5rem;
+    background-color: white;
+    margin-bottom: 15px;
 }
+
 .chat-block .chat-sidebar .chat-sidebar-content .list-group .list-group-item .badge {
-  width: 30px;
-  height: 30px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+    width: 30px;
+    height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
+
 .chat-block .chat-sidebar .chat-sidebar-content .chat-lists {
-  padding: 1px 0;
+    padding: 1px 0;
 }
+
 .chat-block .chat-sidebar .chat-sidebar-content .chat-lists .list-group .list-group-item {
-  cursor: pointer;
+    cursor: pointer;
 }
+
 .chat-block .chat-sidebar .chat-sidebar-content .chat-lists .list-group .list-group-item:not(.active):hover {
-  background: #f2f2f2;
+    background: #f2f2f2;
 }
+
 .chat-block .chat-sidebar .chat-sidebar-content .chat-lists .list-group .list-group-item.active {
-  position: relative;
-  color: black;
-  margin-top: 0;
-  box-shadow: 0 0 0 1px #5149e5 !important;
+    position: relative;
+    color: black;
+    margin-top: 0;
+    box-shadow: 0 0 0 1px #5149e5 !important;
 }
+
 .chat-block .chat-sidebar .chat-sidebar-content .chat-lists .list-group .list-group-item.unread-message {
-  font-weight: bold;
+    font-weight: bold;
 }
+
 .chat-block .chat-sidebar .chat-sidebar-content .chat-lists .list-group .list-group-item.unread-message p {
-  color: #05b171;
+    color: #05b171;
 }
-.chat-block .empty-chat-wrapper .chat-header, .chat-block .empty-chat-wrapper .messages, .chat-block .empty-chat-wrapper .chat-footer {
-  display: none !important;
+
+.chat-block .empty-chat-wrapper .chat-header,
+.chat-block .empty-chat-wrapper .messages,
+.chat-block .empty-chat-wrapper .chat-footer {
+    display: none !important;
 }
+
 .chat-block .empty-chat-wrapper .empty-chat {
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-direction: column;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
 }
+
 .chat-block .chat-content {
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  height: 100%;
-  padding-left: 30px;
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    height: 100%;
+    padding-left: 30px;
 }
+
 .chat-block .chat-content .mobile-chat-close-btn {
-  display: none;
+    display: none;
 }
+
 .chat-block .chat-content .messages {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  flex: 1;
-  overflow-x: hidden;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    flex: 1;
+    overflow-x: hidden;
 }
+
 .chat-block .chat-content .messages .message-item {
-  margin-bottom: 20px;
-  display: flex;
-  align-items: center;
-  position: relative;
+    margin-bottom: 20px;
+    display: flex;
+    align-items: center;
+    position: relative;
 }
+
 .chat-block .chat-content .messages .message-item .time {
-  margin-left: 1rem;
+    margin-left: 1rem;
 }
+
 .chat-block .chat-content .messages .message-item img {
-  max-width: 30%;
-  border-radius: 0.5rem;
+    max-width: 30%;
+    border-radius: 0.5rem;
 }
+
 .chat-block .chat-content .messages .message-item .message-item-content {
-  max-width: 75%;
-  background-color: white;
-  padding: 10px 20px;
-  line-height: 1.5rem;
-  border-radius: 0.5rem;
-  position: relative;
-  z-index: 2;
+    max-width: 75%;
+    background-color: white;
+    padding: 10px 20px;
+    line-height: 1.5rem;
+    border-radius: 0.5rem;
+    position: relative;
+    z-index: 2;
 }
+
 .chat-block .chat-content .messages .message-item.me {
-  flex-direction: row-reverse;
-  margin-left: auto;
-  padding-left: 0;
+    flex-direction: row-reverse;
+    margin-left: auto;
+    padding-left: 0;
 }
+
 .chat-block .chat-content .messages .message-item.me .time {
-  margin-left: 0;
-  margin-right: 1rem;
+    margin-left: 0;
+    margin-right: 1rem;
 }
+
 .chat-block .chat-content .messages .message-item.me .message-item-content {
-  background-color: #d1cff8;
-  border-color: transparent;
+    background-color: #d1cff8;
+    border-color: transparent;
 }
+
 .chat-block .chat-content .messages .message-item.message-item-divider {
-  width: 100%;
-  display: flex;
+    width: 100%;
+    display: flex;
 }
+
 .chat-block .chat-content .messages .message-item.message-item-divider span {
-  padding: 0 10px;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-          user-select: none;
+    padding: 0 10px;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    user-select: none;
 }
-.chat-block .chat-content .messages .message-item.message-item-divider:before, .chat-block .chat-content .messages .message-item.message-item-divider:after {
-  content: "";
-  display: block;
-  height: 1px;
-  background-color: #f0f0f0;
-  flex: 1;
+
+.chat-block .chat-content .messages .message-item.message-item-divider:before,
+.chat-block .chat-content .messages .message-item.message-item-divider:after {
+    content: "";
+    display: block;
+    height: 1px;
+    background-color: #f0f0f0;
+    flex: 1;
 }
+
 .chat-block .chat-content .chat-footer {
-  padding-top: 30px;
+    padding-top: 30px;
 }
+
 .chat-block .chat-content .chat-footer .mb-3 {
-  margin: 0;
-  position: relative;
-  display: flex;
-  align-items: center;
+    margin: 0;
+    position: relative;
+    display: flex;
+    align-items: center;
 }
-.chat-block .chat-content .chat-footer .mb-3 .form-control, .chat-block .chat-content .chat-footer .mb-3 .swal2-modal .swal2-input, .swal2-modal .chat-block .chat-content .chat-footer .mb-3 .swal2-input {
-  margin: 0 15px;
-  border-radius: 50px;
-  padding-left: 20px;
+
+.chat-block .chat-content .chat-footer .mb-3 .form-control,
+.chat-block .chat-content .chat-footer .mb-3 .swal2-modal .swal2-input,
+.swal2-modal .chat-block .chat-content .chat-footer .mb-3 .swal2-input {
+    margin: 0 15px;
+    border-radius: 50px;
+    padding-left: 20px;
 }
 
 table.dataTable thead .sorting:before,
@@ -13166,608 +2876,709 @@ table.dataTable thead .sorting_asc:before,
 table.dataTable thead .sorting_asc:after,
 table.dataTable thead .sorting_desc:before,
 table.dataTable thead .sorting_desc:after {
-  top: 50%;
-  transform: translateY(-50%);
+    top: 50%;
+    transform: translateY(-50%);
 }
 
 .table {
-  min-width: 100%;
-  margin-bottom: 0;
+    min-width: 100%;
+    margin-bottom: 0;
 }
+
 .table thead th {
-  text-transform: uppercase;
-  font-size: 12px;
-  letter-spacing: 1px;
-  font-weight: 500;
+    text-transform: uppercase;
+    font-size: 12px;
+    letter-spacing: 1px;
+    font-weight: 500;
 }
+
 .table td {
-  vertical-align: middle;
-  white-space: nowrap;
+    vertical-align: middle;
+    white-space: nowrap;
 }
+
 .table .dropdown-menu {
-  margin-top: 0;
+    margin-top: 0;
 }
+
 .table.table-lg td {
-  padding: 1.3rem 0.75rem;
+    padding: 1.3rem 0.75rem;
 }
+
 .table.table-borderless td {
-  padding-left: 0;
-  padding-right: 0;
+    padding-left: 0;
+    padding-right: 0;
 }
+
 .table th {
-  vertical-align: middle !important;
+    vertical-align: middle !important;
 }
+
 .table.table-striped tbody tr:nth-of-type(odd) {
-  background-color: rgba(0, 0, 0, 0.03);
+    background-color: rgba(0, 0, 0, 0.03);
 }
+
 .table.table-custom {
-  border-spacing: 0 15px;
-  border-collapse: separate;
+    border-spacing: 0 15px;
+    border-collapse: separate;
 }
+
 .table.table-custom thead tr th {
-  border: none;
+    border: none;
 }
+
 .table.table-custom tbody tr {
-  background: white;
+    background: white;
 }
+
 .table.table-custom tbody tr td {
-  border-top: 1px solid transparent;
-  border-bottom: 1px solid transparent;
+    border-top: 1px solid transparent;
+    border-bottom: 1px solid transparent;
 }
+
 .table.table-custom tbody tr td:first-child {
-  border-left: 1px solid transparent;
+    border-left: 1px solid transparent;
 }
+
 .table.table-custom tbody tr td:last-child {
-  border-right: 1px solid transparent;
+    border-right: 1px solid transparent;
 }
+
 .table.table-custom tbody tr.tr-selected td {
-  border-color: #5149e5 !important;
+    border-color: #5149e5 !important;
 }
+
 .table.table-custom tbody tr td:first-child {
-  border-top-left-radius: 0.5rem;
-  border-bottom-left-radius: 0.5rem;
-  padding-left: 15px;
+    border-top-left-radius: 0.5rem;
+    border-bottom-left-radius: 0.5rem;
+    padding-left: 15px;
 }
+
 .table.table-custom tbody tr td:last-child {
-  border-top-right-radius: 0.5rem;
-  border-bottom-right-radius: 0.5rem;
-  padding-right: 15px;
+    border-top-right-radius: 0.5rem;
+    border-bottom-right-radius: 0.5rem;
+    padding-right: 15px;
 }
+
 .table.table-custom tbody tr:last-child td {
-  border-bottom-color: transparent;
+    border-bottom-color: transparent;
 }
 
 .card table.table-custom tbody tr {
-  background: white;
+    background: white;
 }
+
 .card table.table-custom tbody tr td {
-  border-top: 1px solid var(--bs-border-color-translucent);
-  border-bottom: 1px solid var(--bs-border-color-translucent);
+    border-top: 1px solid var(--bs-border-color-translucent);
+    border-bottom: 1px solid var(--bs-border-color-translucent);
 }
+
 .card table.table-custom tbody tr td:first-child {
-  border-left: 1px solid var(--bs-border-color-translucent);
+    border-left: 1px solid var(--bs-border-color-translucent);
 }
+
 .card table.table-custom tbody tr td:last-child {
-  border-right: 1px solid var(--bs-border-color-translucent);
+    border-right: 1px solid var(--bs-border-color-translucent);
 }
 
 .table-responsive-stack tr {
-  display: flex;
-  flex-direction: row;
+    display: flex;
+    flex-direction: row;
 }
 
 .table-responsive-stack td,
 .table-responsive-stack th {
-  display: block;
-  flex: 1 1 auto;
+    display: block;
+    flex: 1 1 auto;
 }
 
 .dd-handle {
-  padding: 10px 20px;
-  height: auto;
-  margin: 10px 0;
-  border-radius: 0.5rem;
-}
-.dd-handle:hover {
-  color: #5149e5;
+    padding: 10px 20px;
+    height: auto;
+    margin: 10px 0;
+    border-radius: 0.5rem;
 }
 
-.dd-item > button {
-  margin: 10px 0;
-  margin-left: 5px;
+.dd-handle:hover {
+    color: #5149e5;
+}
+
+.dd-item>button {
+    margin: 10px 0;
+    margin-left: 5px;
 }
 
 .menu {
-  z-index: 998;
-  width: 350px;
-  position: fixed;
-  left: 0;
-  bottom: 0;
-  top: 0;
-  display: flex;
-  flex-direction: column;
+    z-index: 998;
+    width: 350px;
+    position: fixed;
+    left: 0;
+    bottom: 0;
+    top: 0;
+    display: flex;
+    flex-direction: column;
 }
+
 .menu-header {
-  padding: 0 1.5rem;
-  padding-bottom: 0.5rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+    padding: 0 1.5rem;
+    padding-bottom: 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 }
+
 .menu-header-logo {
-  display: flex;
-  align-items: center;
-  height: 90px;
-  gap: 15px;
+    display: flex;
+    align-items: center;
+    height: 90px;
+    gap: 15px;
 }
+
 .menu-header-logo img {
-  width: 35px;
+    width: 35px;
 }
+
 .menu-header-logo span {
-  font-size: 22px;
-  color: black;
-  font-weight: 600;
+    font-size: 22px;
+    color: black;
+    font-weight: 600;
 }
+
 .menu-header .menu-close-btn {
-  display: none;
-  background-color: white;
-  border-radius: 0.5rem;
-  font-size: 25px;
+    display: none;
+    background-color: white;
+    border-radius: 0.5rem;
+    font-size: 25px;
 }
+
 .menu-body {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  position: relative;
-  padding: 1.5rem;
-  padding-top: 0;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    padding: 1.5rem;
+    padding-top: 0;
 }
+
 .menu-body .dropdown {
-  margin-bottom: 20px;
-  background-color: white;
-  border-radius: 0.5rem;
-  padding: 15px;
+    margin-bottom: 20px;
+    background-color: white;
+    border-radius: 0.5rem;
+    padding: 15px;
 }
+
 .menu-body ul {
-  margin: 0;
-  padding: 0;
+    margin: 0;
+    padding: 0;
 }
+
 .menu-body ul li {
-  list-style-type: none;
+    list-style-type: none;
 }
+
 .menu-body ul li.menu-divider {
-  display: block;
-  padding: 20px;
-  margin-top: 20px;
-  font-size: 12px;
-  opacity: 0.6;
+    display: block;
+    padding: 20px;
+    margin-top: 20px;
+    font-size: 12px;
+    opacity: 0.6;
 }
+
 .menu-body ul li.menu-divider:first-child {
-  margin-top: 0;
-  padding-top: 0;
+    margin-top: 0;
+    padding-top: 0;
 }
-.menu-body ul li > a {
-  display: flex;
-  align-items: center;
-  padding: 10px 20px;
-  color: black;
-  font-size: 15px;
-  transition: background 0.2s, color 0.2s;
-  border-radius: 5rem;
-  border-right: 4px solid transparent;
-  border-left: 4px solid transparent;
+
+.menu-body ul li>a {
+    display: flex;
+    align-items: center;
+    padding: 10px 20px;
+    color: black;
+    font-size: 15px;
+    transition: background 0.2s, color 0.2s;
+    border-radius: 5rem;
+    border-right: 4px solid transparent;
+    border-left: 4px solid transparent;
 }
-.menu-body ul li > a .nav-link-icon {
-  margin-right: 12px;
-  font-size: 22px;
-  line-height: 18px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 35px;
-  height: 35px;
-  border-radius: 50%;
-  transition: transform 0.2s;
+
+.menu-body ul li>a .nav-link-icon {
+    margin-right: 12px;
+    font-size: 22px;
+    line-height: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 35px;
+    height: 35px;
+    border-radius: 50%;
+    transition: transform 0.2s;
 }
-.menu-body ul li > a .badge.rounded-circle {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+
+.menu-body ul li>a .badge.rounded-circle {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
-.menu-body ul li > a .sub-menu-arrow {
-  margin-left: 12px;
-  opacity: 0.6;
-  font-size: 13px;
-  transition: transform 0.2s;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+
+.menu-body ul li>a .sub-menu-arrow {
+    margin-left: 12px;
+    opacity: 0.6;
+    font-size: 13px;
+    transition: transform 0.2s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
-.menu-body ul li > a .sub-menu-arrow.rotate-in {
-  transform: rotate(90deg);
+
+.menu-body ul li>a .sub-menu-arrow.rotate-in {
+    transform: rotate(90deg);
 }
-.menu-body ul li > a:hover {
-  color: #5149e5;
+
+.menu-body ul li>a:hover {
+    color: #5149e5;
 }
-.menu-body ul li > a:hover:not(.active) .nav-link-icon {
-  transform: scale(1.15);
+
+.menu-body ul li>a:hover:not(.active) .nav-link-icon {
+    transform: scale(1.15);
 }
-.menu-body ul li > a.active {
-  position: relative;
-  background: rgba(81, 73, 229, 0.15);
-  color: #5149e5;
-  border-left-color: #5149e5;
-  border-right-color: #5149e5;
+
+.menu-body ul li>a.active {
+    position: relative;
+    background: rgba(81, 73, 229, 0.15);
+    color: #5149e5;
+    border-left-color: #5149e5;
+    border-right-color: #5149e5;
 }
-.menu-body ul li > a.active .nav-link-icon {
-  background-color: #f5f4fe;
-  font-size: 18px;
+
+.menu-body ul li>a.active .nav-link-icon {
+    background-color: #f5f4fe;
+    font-size: 18px;
 }
-.menu-body ul li > a.disabled {
-  cursor: no-drop;
-  color: rgba(0, 0, 0, 0.5);
+
+.menu-body ul li>a.disabled {
+    cursor: no-drop;
+    color: rgba(0, 0, 0, 0.5);
 }
-.menu-body ul li > a + ul {
-  display: none;
+
+.menu-body ul li>a+ul {
+    display: none;
 }
-.menu-body ul li > a + ul li a {
-  padding-left: 67px;
+
+.menu-body ul li>a+ul li a {
+    padding-left: 67px;
 }
-.menu-body ul li > a + ul ul {
-  box-shadow: none;
-  margin: 0;
-  padding: 0;
-  border-left: none;
+
+.menu-body ul li>a+ul ul {
+    box-shadow: none;
+    margin: 0;
+    padding: 0;
+    border-left: none;
 }
-.menu-body ul li > a + ul ul li a {
-  padding-left: 80px;
+
+.menu-body ul li>a+ul ul li a {
+    padding-left: 80px;
 }
-.menu-body ul li.open > ul {
-  display: block;
+
+.menu-body ul li.open>ul {
+    display: block;
 }
+
 .menu-footer {
-  padding: 1.5rem;
+    padding: 1.5rem;
 }
 
 @media (min-width: 1200px) {
-  body.sidebar-active {
-    transition: transform 0.5s;
-    transform: translateX(-420px);
-  }
+    body.sidebar-active {
+        transition: transform 0.5s;
+        transform: translateX(-420px);
+    }
 }
+
 .sidebar {
-  width: 420px;
-  background-color: white;
-  z-index: 1000;
-  visibility: hidden;
-  opacity: 0;
-  position: fixed;
-  right: -100%;
-  bottom: 0;
-  top: 0;
-  display: flex;
-  flex-direction: column;
-  transition: all 0.2s;
+    width: 420px;
+    background-color: white;
+    z-index: 1000;
+    visibility: hidden;
+    opacity: 0;
+    position: fixed;
+    right: -100%;
+    bottom: 0;
+    top: 0;
+    display: flex;
+    flex-direction: column;
+    transition: all 0.2s;
 }
+
 @media (min-width: 1200px) {
-  .sidebar {
-    transform: translateX(420px);
-  }
+    .sidebar {
+        transform: translateX(420px);
+    }
 }
+
 .sidebar-header {
-  padding: 0 30px;
-  min-height: 90px;
-  font-size: 20px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  border-bottom: 1px solid #e6e6e6;
+    padding: 0 30px;
+    min-height: 90px;
+    font-size: 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid #e6e6e6;
 }
+
 .sidebar-header .nav.nav-pills {
-  width: 100%;
+    width: 100%;
 }
+
 .sidebar-header .nav.nav-pills .nav-item {
-  flex: 1;
+    flex: 1;
 }
+
 .sidebar-header .nav.nav-pills .nav-item .nav-link {
-  text-align: center;
-  border-radius: 0;
-  font-size: 15px;
-  padding: 15px 10px;
-  border-top-left-radius: 0.5rem;
-  border-top-right-radius: 0.5rem;
+    text-align: center;
+    border-radius: 0;
+    font-size: 15px;
+    padding: 15px 10px;
+    border-top-left-radius: 0.5rem;
+    border-top-right-radius: 0.5rem;
 }
+
 .sidebar-header .nav.nav-pills .nav-item .nav-link.nav-link-notify {
-  position: relative;
+    position: relative;
 }
+
 .sidebar-header .nav.nav-pills .nav-item .nav-link.nav-link-notify:before {
-  content: "";
-  position: absolute;
-  width: 10px;
-  height: 10px;
-  left: 10px;
-  border-radius: 50%;
-  top: 10px;
-  background-color: #faae42;
+    content: "";
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    left: 10px;
+    border-radius: 50%;
+    top: 10px;
+    background-color: #faae42;
 }
+
 .sidebar-content {
-  flex: 1;
-  overflow: auto;
-  padding: 20px 30px;
+    flex: 1;
+    overflow: auto;
+    padding: 20px 30px;
 }
+
 .sidebar-content .list-group-item {
-  background: none;
+    background: none;
 }
+
 .sidebar-action {
-  padding: 15px 30px;
+    padding: 15px 30px;
 }
+
 .sidebar [data-sidebar-close] {
-  border-radius: 50%;
-  color: rgba(0, 0, 0, 0.75);
-  background: none;
-  border: none;
-  padding: 0;
-  font-size: 25px;
-  line-height: 0;
-  width: 50px;
-  height: 50px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+    border-radius: 50%;
+    color: rgba(0, 0, 0, 0.75);
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 25px;
+    line-height: 0;
+    width: 50px;
+    height: 50px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
-.sidebar [data-sidebar-close]:focus, .sidebar [data-sidebar-close]:active {
-  outline: none;
-  color: #5149e5;
-  background: rgba(81, 73, 229, 0.1);
+
+.sidebar [data-sidebar-close]:focus,
+.sidebar [data-sidebar-close]:active {
+    outline: none;
+    color: #5149e5;
+    background: rgba(81, 73, 229, 0.1);
 }
+
 .sidebar.show {
-  visibility: visible;
-  opacity: 1;
-  right: 0;
+    visibility: visible;
+    opacity: 1;
+    right: 0;
 }
+
 @media (min-width: 1200px) {
-  .sidebar.show {
-    transform: translateX(420px);
-  }
+    .sidebar.show {
+        transform: translateX(420px);
+    }
 }
-.sidebar > header {
-  background-color: #ebebeb;
-  padding: 1.5rem;
-  font-size: 16px;
-  line-height: 0;
-  display: flex;
-  align-items: center;
+
+.sidebar>header {
+    background-color: #ebebeb;
+    padding: 1.5rem;
+    font-size: 16px;
+    line-height: 0;
+    display: flex;
+    align-items: center;
 }
-.sidebar > header i {
-  margin-right: 10px;
+
+.sidebar>header i {
+    margin-right: 10px;
 }
+
 .sidebar .tab-content {
-  height: 100%;
+    height: 100%;
 }
+
 .sidebar .tab-content .tab-pane.active {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
 }
+
 .sidebar .tab-content .tab-pane.active .tab-pane-body {
-  flex: 1;
-  overflow: auto;
+    flex: 1;
+    overflow: auto;
 }
+
 .sidebar .tab-content .tab-pane.active .tab-pane-footer {
-  padding-top: 20px;
+    padding-top: 20px;
 }
 
 footer.content-footer {
-  padding: 1.5rem;
-  padding-top: 0;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+    padding: 1.5rem;
+    padding-top: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 }
+
 footer.content-footer .nav a {
-  padding: 0;
+    padding: 0;
 }
+
 footer.content-footer .nav a:hover {
-  background: none !important;
+    background: none !important;
 }
 
 .demo-icon-list {
-  height: 100px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 20px;
-  border-radius: 0.5rem;
+    height: 100px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 20px;
+    border-radius: 0.5rem;
 }
+
 .demo-icon-list:hover {
-  background-color: #f2f2f2;
+    background-color: #f2f2f2;
 }
 
 .theme-customizer {
-  position: fixed;
-  right: 0;
-  top: 50%;
-  margin-top: -25px;
-  z-index: 9998;
-  display: flex;
-  align-items: center;
-}
-.theme-customizer button {
-  width: 50px;
-  height: 50px;
-  font-size: 20px;
-  color: white;
-  border-top-left-radius: 10px;
-  border-bottom-left-radius: 10px;
-  background-color: #5149e5;
-  border: none;
-}
-.theme-customizer button i {
-  display: block;
-  animation-name: spin;
-  animation-duration: 2000ms;
-  animation-iteration-count: infinite;
-  animation-timing-function: linear;
-}
-.theme-customizer button:focus {
-  outline: none;
-}
-.theme-customizer button:hover {
-  background-color: #291fdc;
-}
-.theme-customizer .theme-customizer-body {
-  display: none;
-}
-.theme-customizer .theme-customizer-body.open {
-  display: block;
-}
-.theme-customizer .theme-customizer-body .theme-colors {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 50px;
-  border: 1px solid #5149e5;
-  background-color: white;
-  border-right: none;
-  padding: 0 10px;
-}
-.theme-customizer .theme-customizer-body .theme-colors a {
-  margin: 0 4px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-}
-.theme-customizer .theme-customizer-body .theme-colors a.active:before {
-  content: "\e64c";
-  font-family: themify;
-  color: white;
-}
-
-@keyframes spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-.card-body + .demo-code-preview {
-  border-top: 1px solid #e6e6e6;
-}
-
-.demo-code-preview {
-  position: relative;
-  padding: 1rem 1.5rem;
-  border-bottom-left-radius: 0.5rem;
-  border-bottom-right-radius: 0.5rem;
-}
-.demo-code-preview:before {
-  content: attr(data-label);
-  display: none;
-  position: absolute;
-  top: -9px;
-  left: 20px;
-  letter-spacing: 1px;
-  background-color: inherit;
-  font-size: 11px;
-  padding: 0 5px;
-}
-.demo-code-preview pre {
-  overflow-x: hidden;
-  background: none;
-  padding: 0;
-  max-height: 500px;
-}
-.demo-code-preview pre code {
-  font-size: 14px;
-}
-.demo-code-preview:hover pre {
-  overflow-x: auto;
-}
-
-@media (max-width: 768px) {
-  .theme-switcher {
-    display: none;
-  }
-}
-@media (min-width: 768px) {
-  .theme-switcher {
+    position: fixed;
+    right: 0;
+    top: 50%;
+    margin-top: -25px;
+    z-index: 9998;
     display: flex;
     align-items: center;
-    position: fixed;
-    right: -250px;
-    top: 50%;
-    transform: translate(0, -50%);
-    -webkit-user-select: none;
-       -moz-user-select: none;
-            user-select: none;
-    z-index: 9999;
-    transition: right 0.3s;
-  }
-  .theme-switcher.open {
-    right: 0;
-  }
-  .theme-switcher .theme-switcher-button {
-    background-color: #5149e5;
+}
+
+.theme-customizer button {
+    width: 50px;
+    height: 50px;
+    font-size: 20px;
     color: white;
-    padding: 15px 20px;
-    border-top-left-radius: 5px;
-    border-bottom-left-radius: 5px;
-    cursor: pointer;
-  }
-  .theme-switcher .theme-switcher-button i {
-    font-size: 30px;
+    border-top-left-radius: 10px;
+    border-bottom-left-radius: 10px;
+    background-color: #5149e5;
+    border: none;
+}
+
+.theme-customizer button i {
+    display: block;
     animation-name: spin;
     animation-duration: 2000ms;
     animation-iteration-count: infinite;
     animation-timing-function: linear;
-  }
-  .theme-switcher .theme-switcher-panel {
-    width: 250px;
-  }
-  .theme-switcher .theme-switcher-panel .card {
-    margin-bottom: 0;
+}
+
+.theme-customizer button:focus {
+    outline: none;
+}
+
+.theme-customizer button:hover {
+    background-color: #291fdc;
+}
+
+.theme-customizer .theme-customizer-body {
+    display: none;
+}
+
+.theme-customizer .theme-customizer-body.open {
+    display: block;
+}
+
+.theme-customizer .theme-customizer-body .theme-colors {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 50px;
     border: 1px solid #5149e5;
+    background-color: white;
     border-right: none;
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-  }
-  @keyframes spin {
+    padding: 0 10px;
+}
+
+.theme-customizer .theme-customizer-body .theme-colors a {
+    margin: 0 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+}
+
+.theme-customizer .theme-customizer-body .theme-colors a.active:before {
+    content: "\e64c";
+    font-family: themify;
+    color: white;
+}
+
+@keyframes spin {
     from {
-      transform: rotate(0deg);
+        transform: rotate(0deg);
     }
+
     to {
-      transform: rotate(360deg);
+        transform: rotate(360deg);
     }
-  }
 }
+
+.card-body+.demo-code-preview {
+    border-top: 1px solid #e6e6e6;
+}
+
+.demo-code-preview {
+    position: relative;
+    padding: 1rem 1.5rem;
+    border-bottom-left-radius: 0.5rem;
+    border-bottom-right-radius: 0.5rem;
+}
+
+.demo-code-preview:before {
+    content: attr(data-label);
+    display: none;
+    position: absolute;
+    top: -9px;
+    left: 20px;
+    letter-spacing: 1px;
+    background-color: inherit;
+    font-size: 11px;
+    padding: 0 5px;
+}
+
+.demo-code-preview pre {
+    overflow-x: hidden;
+    background: none;
+    padding: 0;
+    max-height: 500px;
+}
+
+.demo-code-preview pre code {
+    font-size: 14px;
+}
+
+.demo-code-preview:hover pre {
+    overflow-x: auto;
+}
+
+@media (max-width: 768px) {
+    .theme-switcher {
+        display: none;
+    }
+}
+
+@media (min-width: 768px) {
+    .theme-switcher {
+        display: flex;
+        align-items: center;
+        position: fixed;
+        right: -250px;
+        top: 50%;
+        transform: translate(0, -50%);
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        user-select: none;
+        z-index: 9999;
+        transition: right 0.3s;
+    }
+
+    .theme-switcher.open {
+        right: 0;
+    }
+
+    .theme-switcher .theme-switcher-button {
+        background-color: #5149e5;
+        color: white;
+        padding: 15px 20px;
+        border-top-left-radius: 5px;
+        border-bottom-left-radius: 5px;
+        cursor: pointer;
+    }
+
+    .theme-switcher .theme-switcher-button i {
+        font-size: 30px;
+        animation-name: spin;
+        animation-duration: 2000ms;
+        animation-iteration-count: infinite;
+        animation-timing-function: linear;
+    }
+
+    .theme-switcher .theme-switcher-panel {
+        width: 250px;
+    }
+
+    .theme-switcher .theme-switcher-panel .card {
+        margin-bottom: 0;
+        border: 1px solid #5149e5;
+        border-right: none;
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+    }
+
+    @keyframes spin {
+        from {
+            transform: rotate(0deg);
+        }
+
+        to {
+            transform: rotate(360deg);
+        }
+    }
+}
+
 body.top-menu .header .logo {
-  display: block;
+    display: block;
 }
+
 body.top-menu .menu {
-  display: none;
+    display: none;
 }
+
 body.top-menu .layout-wrapper {
-  margin-left: 0;
+    margin-left: 0;
 }
+
 @media (min-width: 1400px) {
-  body.top-menu .layout-wrapper {
-    max-width: 1320px;
-    margin-left: auto;
-    margin-right: auto;
-  }
+    body.top-menu .layout-wrapper {
+        max-width: 1320px;
+        margin-left: auto;
+        margin-right: auto;
+    }
 }
+
 @media (max-width: 1200px) {
-  body.top-menu .header .header-menu ul.navbar-nav > li.open > a {
-    background: none !important;
-    border-color: transparent !important;
-  }
+    body.top-menu .header .header-menu ul.navbar-nav>li.open>a {
+        background: none !important;
+        border-color: transparent !important;
+    }
 }
 
 /*
@@ -13777,1011 +3588,19 @@ Therefore, other style codes for the parent menu are managed from the ./componen
 
 */
 body.hidden-menu .menu {
-  display: none;
-}
-body.hidden-menu .header .logos {
-  display: block;
-}
-body.hidden-menu .header .menu-toggle-btn {
-  display: block;
-}
-body.hidden-menu .menu {
-  display: none;
-  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
-  width: 350px;
-  position: fixed;
-  display: flex;
-  flex-direction: column;
-  left: -110% !important;
-  opacity: 0;
-  bottom: 0;
-  top: 0;
-  z-index: 9998 !important;
-  transition: all 0.2s;
-  background-color: white;
-}
-body.hidden-menu .menu .menu-close-btn {
-  display: block;
-}
-body.hidden-menu .menu .dropdown {
-  background-color: #f5f4fe;
-}
-body.hidden-menu .menu.open {
-  left: 0 !important;
-  opacity: 1;
-}
-body.hidden-menu .menu-body {
-  overflow: auto;
-  border-top-left-radius: 0;
-}
-body.hidden-menu .menu-body ul li > a.active .nav-link-icon {
-  background-color: white;
-}
-body.hidden-menu .layout-wrapper {
-  margin-left: 0;
-}
-
-.layout-wrapper {
-  display: flex;
-  flex-direction: column;
-  margin-left: 350px;
-  min-height: 100vh;
-}
-.layout-wrapper > .content {
-  flex: 1;
-  padding: 1.5rem;
-}
-
-body.dark {
-  background-color: #3b3b41;
-  color: #a3a3a3;
-  /* Overrides the border radius setting in the theme. */
-  --ck-border-radius: 4px;
-  /* Overrides the default font size in the theme. */
-  --ck-font-size-base: 14px;
-  /* Helper variables to avoid duplication in the colors. */
-  --ck-custom-background: hsl(270, 1%, 29%);
-  --ck-custom-foreground: hsl(255, 3%, 18%);
-  --ck-custom-border: hsl(300, 1%, 22%);
-  --ck-custom-white: hsl(0, 0%, 80%);
-  /* -- Overrides generic colors. ------------------------------------------------------------- */
-  --ck-color-base-foreground: var(--ck-custom-background);
-  --ck-color-focus-border: hsl(208, 90%, 62%);
-  --ck-color-text: hsl(0, 0%, 98%);
-  --ck-color-shadow-drop: hsla(0, 0%, 0%, 0.2);
-  --ck-color-shadow-inner: hsla(0, 0%, 0%, 0.1);
-  /* -- Overrides the default .ck-button class colors. ---------------------------------------- */
-  --ck-color-button-default-background: var(--ck-custom-background);
-  --ck-color-button-default-hover-background: hsl(270, 1%, 22%);
-  --ck-color-button-default-active-background: hsl(270, 2%, 20%);
-  --ck-color-button-default-active-shadow: hsl(270, 2%, 23%);
-  --ck-color-button-default-disabled-background: var(--ck-custom-background);
-  --ck-color-button-on-background: var(--ck-custom-foreground);
-  --ck-color-button-on-hover-background: hsl(255, 4%, 16%);
-  --ck-color-button-on-active-background: hsl(255, 4%, 14%);
-  --ck-color-button-on-active-shadow: hsl(240, 3%, 19%);
-  --ck-color-button-on-disabled-background: var(--ck-custom-foreground);
-  --ck-color-button-action-background: hsl(168, 76%, 42%);
-  --ck-color-button-action-hover-background: hsl(168, 76%, 38%);
-  --ck-color-button-action-active-background: hsl(168, 76%, 36%);
-  --ck-color-button-action-active-shadow: hsl(168, 75%, 34%);
-  --ck-color-button-action-disabled-background: hsl(168, 76%, 42%);
-  --ck-color-button-action-text: var(--ck-custom-white);
-  --ck-color-button-save: hsl(120, 100%, 46%);
-  --ck-color-button-cancel: hsl(15, 100%, 56%);
-  /* -- Overrides the default .ck-dropdown class colors. -------------------------------------- */
-  --ck-color-dropdown-panel-background: var(--ck-custom-background);
-  --ck-color-dropdown-panel-border: var(--ck-custom-foreground);
-  /* -- Overrides the default .ck-splitbutton class colors. ----------------------------------- */
-  --ck-color-split-button-hover-background: var(--ck-color-button-default-hover-background);
-  --ck-color-split-button-hover-border: var(--ck-custom-foreground);
-  /* -- Overrides the default .ck-input class colors. ----------------------------------------- */
-  --ck-color-input-background: var(--ck-custom-background);
-  --ck-color-input-border: hsl(257, 3%, 43%);
-  --ck-color-input-text: hsl(0, 0%, 98%);
-  --ck-color-input-disabled-background: hsl(255, 4%, 21%);
-  --ck-color-input-disabled-border: hsl(250, 3%, 38%);
-  --ck-color-input-disabled-text: hsl(0, 0%, 78%);
-  /* -- Overrides the default .ck-labeled-field-view class colors. ---------------------------- */
-  --ck-color-labeled-field-label-background: var(--ck-custom-background);
-  /* -- Overrides the default .ck-list class colors. ------------------------------------------ */
-  --ck-color-list-background: var(--ck-custom-background);
-  --ck-color-list-button-hover-background: var(--ck-color-base-foreground);
-  --ck-color-list-button-on-background: var(--ck-color-base-active);
-  --ck-color-list-button-on-background-focus: var(--ck-color-base-active-focus);
-  --ck-color-list-button-on-text: var(--ck-color-base-background);
-  /* -- Overrides the default .ck-balloon-panel class colors. --------------------------------- */
-  --ck-color-panel-background: var(--ck-custom-background);
-  --ck-color-panel-border: var(--ck-custom-border);
-  /* -- Overrides the default .ck-toolbar class colors. --------------------------------------- */
-  --ck-color-toolbar-background: var(--ck-custom-background);
-  --ck-color-toolbar-border: var(--ck-custom-border);
-  /* -- Overrides the default .ck-tooltip class colors. --------------------------------------- */
-  --ck-color-tooltip-background: hsl(252, 7%, 14%);
-  --ck-color-tooltip-text: hsl(0, 0%, 93%);
-  /* -- Overrides the default colors used by the ckeditor5-image package. --------------------- */
-  --ck-color-image-caption-background: hsl(0, 0%, 97%);
-  --ck-color-image-caption-text: hsl(0, 0%, 20%);
-  /* -- Overrides the default colors used by the ckeditor5-widget package. -------------------- */
-  --ck-color-widget-blurred-border: hsl(0, 0%, 87%);
-  --ck-color-widget-hover-border: hsl(43, 100%, 68%);
-  --ck-color-widget-editable-focus-background: var(--ck-custom-white);
-  /* -- Overrides the default colors used by the ckeditor5-link package. ---------------------- */
-  --ck-color-link-default: hsl(190, 100%, 75%);
-  --ck-color-base-background: $dark-mode-color-1;
-}
-body.dark .preloader {
-  background-color: #3b3b41;
-}
-body.dark .preloader .preloader-icon {
-  border-color: #3b3b41;
-  border-top-color: #5149e5;
-}
-body.dark .pagination .page-item:not(.active) .page-link {
-  background-color: #323236;
-  border-color: #47474e;
-}
-body.dark .progress {
-  background-color: #47474e;
-}
-body.dark .border {
-  border-color: #47474e !important;
-}
-body.dark .border-top {
-  border-top-color: #47474e !important;
-}
-body.dark .border-bottom {
-  border-bottom-color: #47474e !important;
-}
-body.dark .border-end {
-  border-right-color: #47474e !important;
-}
-body.dark .border-start {
-  border-left-color: #47474e !important;
-}
-body.dark .dropdown-menu {
-  background-color: #47474e;
-  color: inherit;
-}
-body.dark .dropdown-menu .dropdown-header {
-  border-bottom-color: #5f5f69;
-}
-body.dark .dropdown-menu .dropdown-divider {
-  border-top-color: #5f5f69;
-  opacity: 1;
-}
-body.dark .dropdown-menu .dropdown-item {
-  color: #a3a3a3;
-}
-body.dark .dropdown-menu .dropdown-item:hover {
-  color: #d7d7d7;
-}
-body.dark .dropdown-menu .list-group-item {
-  background-color: #47474e;
-}
-body.dark .dropdown-menu .border-top {
-  border-top-color: #5f5f69 !important;
-}
-body.dark .dropdown-menu .border-bottom {
-  border-bottom-color: #5f5f69 !important;
-}
-body.dark .wizard > .steps .disabled a, body.dark .wizard > .steps .disabled a:hover, body.dark .wizard > .steps .disabled a:active {
-  background-color: #323236;
-}
-body.dark .wizard .wizard-index {
-  background-color: #47474e;
-}
-body.dark .wizard .current .wizard-index, body.dark .wizard .done .wizard-index {
-  background-color: rgba(255, 255, 255, 0.15);
-}
-body.dark .wizard > .actions a, body.dark .wizard > .actions a:active, body.dark .wizard > .actions a:hover {
-  color: white !important;
-}
-body.dark .wizard > .actions .disabled a, body.dark .wizard > .actions .disabled a:hover, body.dark .wizard > .actions .disabled a:active {
-  color: #aaaaaa !important;
-  background-color: #47474e !important;
-}
-body.dark.auth {
-  background-color: #3b3b41;
-}
-body.dark.auth .social-links a {
-  border-color: #47474e;
-  color: #a3a3a3;
-}
-body.dark.auth .social-links a:hover {
-  color: #d7d7d7;
-  border-color: #5149e5;
-}
-body.dark .chat-block .chat-sidebar .chat-sidebar-content .list-group .list-group-item {
-  background-color: #323236;
-}
-body.dark .chat-block .chat-sidebar .chat-sidebar-content .list-group .list-group-item:not(.active):hover {
-  background-color: #2b2b2e;
-}
-body.dark .chat-block .chat-sidebar .chat-sidebar-content .list-group .list-group-item.active {
-  color: inherit;
-}
-body.dark .chat-block .chat-content .messages .message-item .message-item-content {
-  background-color: #323236;
-}
-body.dark .chat-block .chat-content .messages .message-item.me .message-item-content {
-  background: rgba(81, 73, 229, 0.15);
-  color: #d7d7d7;
-}
-body.dark .chat-block .chat-content .messages .message-item.message-item-divider:after, body.dark .chat-block .chat-content .messages .message-item.message-item-divider:before {
-  background-color: #5f5f69;
-}
-body.dark .form-switch .form-check-input {
-  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='#47474e'/%3E%3C/svg%3E");
-}
-body.dark .form-switch .form-check-input:checked {
-  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='rgba(255, 255, 255, 0.5)'/%3E%3C/svg%3E");
-}
-body.dark .form-check-input:not(:checked) {
-  background-color: #3b3b41;
-  border-color: #53535c;
-}
-body.dark .form-check-input:checked[type=radio] {
-  background-image: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='2' fill='%23323236'/></svg>");
-}
-body.dark .form-control-plaintext {
-  color: #a3a3a3;
-}
-body.dark .form-control::-webkit-file-upload-button, .swal2-modal body.dark .swal2-input::-webkit-file-upload-button, body.dark .swal2-modal .swal2-input::-webkit-file-upload-button {
-  background-color: #3b3b41;
-  color: #a3a3a3;
-}
-body.dark .form-control:hover:not(:disabled):not([readonly])::-webkit-file-upload-button, .swal2-modal body.dark .swal2-input:hover:not(:disabled):not([readonly])::-webkit-file-upload-button, body.dark .swal2-modal .swal2-input:hover:not(:disabled):not([readonly])::-webkit-file-upload-button {
-  background-color: #3b3b41;
-}
-body.dark .form-control, .swal2-modal body.dark .swal2-input, body.dark .swal2-modal .swal2-input, body.dark .form-select {
-  background-color: #323236;
-  color: #a3a3a3;
-  border-color: #47474e;
-}
-body.dark .form-select {
-  background-image: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='%237a7a7a' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/></svg>");
-}
-body.dark .input-group-text {
-  border-color: #47474e;
-  color: #a3a3a3;
-  background-color: #47474e;
-}
-body.dark .table {
-  color: #a3a3a3;
-}
-body.dark .table.table-custom tbody tr {
-  background-color: #323236;
-}
-body.dark .table.table-custom tbody tr:not(.tr-selected) td {
-  border-top-color: #323236;
-  border-bottom-color: #323236;
-}
-body.dark .table.table-custom tbody tr:not(.tr-selected) td:first-child {
-  border-left-color: #323236;
-}
-body.dark .table.table-custom tbody tr:not(.tr-selected) td:last-child {
-  border-right-color: #323236;
-}
-body.dark .table > :not(caption) > * > * {
-  border-bottom-color: #47474e;
-}
-body.dark .table-striped > tbody > tr:nth-of-type(odd) {
-  color: #a3a3a3;
-}
-body.dark .table-hover > tbody > tr:hover {
-  color: #a3a3a3;
-}
-body.dark .table > :not(:last-child) > :last-child > * {
-  border-bottom-color: #47474e;
-}
-body.dark .table-active {
-  color: #a3a3a3;
-}
-body.dark tbody, body.dark td, body.dark tfoot, body.dark th, body.dark thead, body.dark tr {
-  border-color: #47474e;
-}
-body.dark .table-light {
-  --bs-table-bg: #47474e;
-  color: #a3a3a3;
-}
-body.dark .card .table.table-custom tbody tr:not(.tr-selected) td {
-  border-top-color: #47474e;
-  border-bottom-color: #47474e;
-}
-body.dark .card .table.table-custom tbody tr:not(.tr-selected) td:first-child {
-  border-left-color: #47474e;
-}
-body.dark .card .table.table-custom tbody tr:not(.tr-selected) td:last-child {
-  border-right-color: #47474e;
-}
-body.dark .table .form-check-input:not(:checked) {
-  background-color: #323236;
-  border-color: #4b4b50;
-}
-body.dark .header {
-  background-color: #3b3b41;
-}
-body.dark .header .search-form .input-group {
-  background-color: #323236;
-}
-body.dark .header .search-form .btn:hover, body.dark .header .search-form .btn:active {
-  color: #a3a3a3 !important;
-}
-body.dark .header .search-form .form-control::-moz-placeholder, body.dark .header .search-form .swal2-modal .swal2-input::-moz-placeholder, .swal2-modal body.dark .header .search-form .swal2-input::-moz-placeholder {
-  color: rgba(255, 255, 255, 0.25);
-}
-body.dark .header .search-form .form-control::placeholder, body.dark .header .search-form .swal2-modal .swal2-input::placeholder, .swal2-modal body.dark .header .search-form .swal2-input::placeholder {
-  color: rgba(255, 255, 255, 0.25);
-}
-body.dark .header .header-menu .dropdown {
-  background-color: #323236;
-}
-body.dark .header .header-menu ul.navbar-nav li .nav-sub-menu > ul {
-  background-color: #47474e;
-}
-body.dark .header .header-menu ul.navbar-nav li a {
-  color: #a3a3a3 !important;
-}
-body.dark .header .header-menu ul.navbar-nav li a.active {
-  color: #d7d7d7 !important;
-}
-body.dark .header .header-menu ul.navbar-nav li a:hover {
-  color: #d7d7d7 !important;
-}
-body.dark .header .header-menu ul.navbar-nav li.open > a {
-  color: #d7d7d7 !important;
-}
-body.dark .header .menu-toggle-btn a, body.dark .header .header-mobile-buttons a {
-  color: #a3a3a3;
-}
-body.dark .header .menu-toggle-btn a:hover, body.dark .header .menu-toggle-btn a:focus, body.dark .header .header-mobile-buttons a:hover, body.dark .header .header-mobile-buttons a:focus {
-  color: #d7d7d7;
-}
-body.dark .header ul.navbar-nav li.nav-item a.nav-link {
-  color: #a3a3a3;
-}
-@media (max-width: 1200px) {
-  body.dark .header .header-menu {
-    background-color: #3b3b41;
-  }
-  body.dark .header .header-menu .header-menu-close {
-    background-color: #3b3b41;
-  }
-  body.dark .header .header-menu .dropdown > a {
-    background-color: #323236;
-  }
-  body.dark .header .header-menu ul.navbar-nav li a:hover {
-    background: none !important;
-    color: white;
-  }
-  body.dark .header .header-menu ul.navbar-nav li .nav-sub-menu > ul {
-    background: none;
-  }
-  body.dark .header .header-menu ul.navbar-nav li .nav-sub-menu > ul li a {
-    color: #a3a3a3;
-  }
-}
-@media (max-width: 768px) {
-  body.dark .header .search-form .input-group {
-    background-color: #3b3b41;
-  }
-  body.dark .header .header-bar {
-    background-color: #323236;
-  }
-}
-body.dark .menu-body .dropdown {
-  background-color: #323236;
-}
-body.dark .menu-body ul li a {
-  color: #a3a3a3;
-}
-body.dark .menu-body ul li a.active {
-  color: #d7d7d7;
-}
-body.dark .menu-body ul li a.active .nav-link-icon {
-  background-color: #3b3b41;
-}
-body.dark .menu-body ul li a:hover {
-  color: #d7d7d7;
-}
-body.dark.hidden-menu .menu {
-  background-color: #3b3b41;
-}
-body.dark.hidden-menu .menu-header .menu-close-btn {
-  background-color: #3b3b41;
-}
-@media (max-width: 1200px) {
-  body.dark .menu {
-    background-color: #3b3b41;
-  }
-  body.dark .menu-header .menu-close-btn {
-    background-color: #3b3b41;
-  }
-}
-body.dark .breadcrumb-item + .breadcrumb-item:before {
-  color: #a3a3a3;
-}
-body.dark .card.widget .card-header {
-  background-color: #3b3b41;
-}
-body.dark .card.widget .card-header + .card-body {
-  background-color: #323236;
-}
-body.dark .card:not(.widget) {
-  background-color: #323236;
-}
-body.dark .card .form-check-input:not(:checked) {
-  background-color: #323236;
-}
-body.dark .card .card {
-  border-color: transparent;
-  border: 1px solid #47474e;
-}
-body.dark .card .avatar {
-  border-color: #323236;
-}
-body.dark .card .avatar:before {
-  border-color: #323236;
-}
-body.dark .card .avatar-group .avatar {
-  border-color: #323236;
-}
-body.dark .card-header {
-  border-bottom-color: #47474e;
-}
-body.dark .card-footer {
-  border-top-color: #47474e;
-}
-body.dark .avatar {
-  border-color: #323236;
-}
-body.dark .avatar:before {
-  border-color: #323236;
-}
-body.dark .avatar-group .avatar {
-  border-color: #323236;
-}
-body.dark .accordion-button {
-  color: inherit;
-  border-color: #47474e;
-}
-body.dark .accordion-button:not(.collapsed) {
-  background-color: rgba(81, 73, 229, 0.15);
-  color: #d7d7d7;
-}
-body.dark .accordion-button:after {
-  background-image: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='%237a7a7a' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/></svg>");
-}
-body.dark .accordion-collapse {
-  border-color: #47474e;
-}
-body.dark .sidebar {
-  background-color: #323236;
-}
-body.dark .sidebar .sidebar-header {
-  border-bottom-color: #47474e;
-}
-body.dark .sidebar [data-sidebar-close] {
-  color: #a3a3a3;
-}
-body.dark .modal-content {
-  background-color: #323236;
-}
-body.dark .modal-content .avatar-group .avatar {
-  border-color: #323236;
-}
-body.dark .modal-header {
-  border-bottom-color: #47474e;
-}
-body.dark .modal-footer {
-  border-top-color: #47474e;
-}
-body.dark .btn-close {
-  background: transparent url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='#a3a3a3' d='M.293.293a1 1 0 011.414 0L8 6.586 14.293.293a1 1 0 111.414 1.414L9.414 8l6.293 6.293a1 1 0 01-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 01-1.414-1.414L6.586 8 .293 1.707a1 1 0 010-1.414z'/></svg>") 50%/1em auto no-repeat;
-}
-body.dark .toast {
-  background-color: #323236;
-}
-body.dark .toast-header {
-  background-color: #3e3e43;
-  color: inherit;
-}
-body.dark .popover {
-  background-color: #47474e;
-}
-body.dark .popover-header {
-  background-color: #47474e;
-  border-bottom-color: #5f5f69;
-}
-body.dark .popover-body {
-  color: inherit;
-}
-body.dark .bs-popover-auto[data-popper-placement^=left] > .popover-arrow:after, body.dark .bs-popover-start > .popover-arrow:after {
-  border-left-color: #47474e;
-}
-body.dark .bs-popover-auto[data-popper-placement^=right] > .popover-arrow:after, body.dark .bs-popover-end > .popover-arrow:after {
-  border-right-color: #47474e;
-}
-body.dark .bs-popover-auto[data-popper-placement^=top] > .popover-arrow:after, body.dark .bs-popover-top > .popover-arrow:after {
-  border-top-color: #47474e;
-}
-body.dark .bs-popover-auto[data-popper-placement^=bottom] > .popover-arrow:after, body.dark .bs-popover-bottom > .popover-arrow:after {
-  border-bottom-color: #47474e;
-}
-body.dark a, body.dark .btn {
-  color: #a3a3a3;
-}
-body.dark a:hover, body.dark .btn:hover {
-  color: #d7d7d7;
-}
-body.dark .btn.btn-light {
-  color: #a3a3a3 !important;
-  background-color: #47474e;
-  border-color: #47474e;
-}
-body.dark .btn.btn-light:hover {
-  color: #d7d7d7 !important;
-}
-body.dark .btn.btn-outline-light {
-  color: #a3a3a3 !important;
-  border-color: #47474e;
-}
-body.dark .btn.btn-outline-light:hover {
-  background-color: #47474e;
-  color: #d7d7d7 !important;
-}
-body.dark .btn.btn-outline-dark {
-  border-color: #1e1e21;
-  color: #a3a3a3 !important;
-}
-body.dark .btn.btn-outline-dark:hover {
-  background-color: #1e1e21 !important;
-}
-body.dark .btn-dark {
-  background-color: #1e1e21 !important;
-  border-color: #1e1e21 !important;
-}
-body.dark.doc .menu {
-  background-color: #323236;
-}
-body.dark .demo-code-preview {
-  border-top-color: #47474e;
-}
-body.dark #TableOfContents ul li a:hover {
-  color: #d7d7d7;
-}
-body.dark .nav-tabs {
-  border-bottom-color: #47474e;
-}
-body.dark .nav-tabs .nav-item.show .nav-link, body.dark .nav-tabs .nav-link.active {
-  background-color: #323236;
-  border-color: #47474e;
-  border-bottom-color: transparent;
-  color: #d7d7d7;
-}
-body.dark .nav-tabs .nav-link:focus, body.dark .nav-tabs .nav-link:hover {
-  border-color: #47474e;
-}
-body.dark code[class*=language-], body.dark pre[class*=language-] {
-  color: #d7d7d7;
-}
-body.dark .token.operator, body.dark .token.entity, body.dark .token.url, body.dark .language-css .token.string, body.dark .style .token.string {
-  background: none;
-}
-body.dark .token.property, body.dark .token.tag, body.dark .token.boolean, body.dark .token.number, body.dark .token.constant, body.dark .token.symbol, body.dark .token.deleted {
-  color: #fa50ae;
-}
-body.dark .dd-handle {
-  background: #323236;
-  border-color: #3b3b41;
-  color: #a3a3a3;
-}
-body.dark .dd-item > button {
-  color: #a3a3a3;
-}
-body.dark .dd-empty, body.dark .dd-placeholder {
-  background: #323236;
-}
-body.dark .slick-wrapper .slick-next:before, body.dark .slick-wrapper .slick-prev:before {
-  color: #a3a3a3;
-}
-body.dark .input-group .btn.btn-outline-light {
-  background-color: #323236;
-}
-body.dark .input-group .form-control + .btn.btn-outline-light, .swal2-modal body.dark .input-group .swal2-input + .btn.btn-outline-light, body.dark .input-group .swal2-modal .swal2-input + .btn.btn-outline-light, body.dark .swal2-modal .input-group .swal2-input + .btn.btn-outline-light {
-  border-right-color: #47474e;
-}
-body.dark .nav.nav-pills .nav-item .nav-link.active {
-  color: #d7d7d7;
-}
-body.dark .text-danger {
-  color: #ff7777 !important;
-}
-body.dark .text-dark {
-  color: #a3a3a3 !important;
-}
-body.dark .text-dark.bg-warning {
-  color: #3b3b41 !important;
-}
-body.dark .text-dark.bg-info {
-  color: #3b3b41 !important;
-}
-body.dark .bg-warning {
-  color: #3b3b41;
-}
-body.dark .bg-info {
-  color: #3b3b41;
-}
-body.dark .border-dark {
-  border-color: #1e1e21 !important;
-}
-body.dark .bg-dark {
-  background-color: #1e1e21 !important;
-}
-body.dark .bg-light {
-  background-color: #3b3b41 !important;
-}
-body.dark .bootstrap-tagsinput {
-  background-color: #323236;
-  border-color: #4e4e56;
-}
-body.dark .bootstrap-tagsinput input {
-  color: #a3a3a3;
-}
-body.dark .dropzone {
-  background-color: #3b3b41;
-  border-color: #4e4e56;
-}
-body.dark .ql-container.ql-snow {
-  background-color: #323236;
-  border-color: #4e4e56;
-}
-body.dark .ql-editor.ql-blank::before {
-  color: rgba(163, 163, 163, 0.6);
-}
-body.dark .select2.select2-container .select2-selection {
-  border-color: #4e4e56;
-}
-body.dark .select2-dropdown {
-  background-color: #323236;
-  border-color: #4e4e56;
-}
-body.dark .select2-container--default .select2-results__option[aria-selected=true] {
-  background-color: #5149e5;
-  color: white;
-}
-body.dark .select2-container--default .select2-selection--multiple, body.dark .select2-container--default .select2-selection--single {
-  background-color: #323236;
-}
-body.dark .select2-container--default .select2-search--inline .select2-search__field, body.dark .select2-container--default .select2-selection--single .select2-selection__rendered {
-  color: #a3a3a3;
-}
-body.dark .select2-container--default .select2-search--dropdown .select2-search__field {
-  background-color: #3b3b41;
-  color: #a3a3a3;
-}
-body.dark .select2-container--default .select2-selection--multiple .select2-selection__choice {
-  background-color: #47474e;
-}
-body.dark .bootstrap-tagsinput .tag {
-  color: #a3a3a3;
-  background-color: #47474e;
-}
-body.dark .carousel-control-prev-icon {
-  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='#323236'%3E%3Cpath d='M11.354 1.646a.5.5 0 010 .708L5.707 8l5.647 5.646a.5.5 0 01-.708.708l-6-6a.5.5 0 010-.708l6-6a.5.5 0 01.708 0z'/%3E%3C/svg%3E");
-}
-body.dark .carousel-control-next-icon {
-  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='#323236'%3E%3Cpath d='M4.646 1.646a.5.5 0 01.708 0l6 6a.5.5 0 010 .708l-6 6a.5.5 0 01-.708-.708L10.293 8 4.646 2.354a.5.5 0 010-.708z'/%3E%3C/svg%3E");
-}
-body.dark .daterangepicker {
-  background-color: #47474e;
-  border-color: #47474e;
-}
-body.dark .daterangepicker .calendar-table .next span, body.dark .daterangepicker .calendar-table .prev span {
-  border-color: #a3a3a3;
-}
-body.dark .daterangepicker .drp-buttons {
-  border-top-color: #5f5f69;
-}
-body.dark .daterangepicker .calendar-table {
-  background-color: #47474e;
-  border-color: #47474e;
-}
-body.dark .daterangepicker td.off, body.dark .daterangepicker td.off.end-date, body.dark .daterangepicker td.off.in-range, body.dark .daterangepicker td.off.start-date {
-  background-color: #47474e;
-}
-body.dark .daterangepicker td.available:hover, body.dark .daterangepicker th.available:hover {
-  background-color: #3b3b41;
-  color: #a3a3a3;
-}
-body.dark .daterangepicker td.off {
-  color: rgba(163, 163, 163, 0.4);
-}
-body.dark .daterangepicker td.in-range {
-  background-color: rgba(81, 73, 229, 0.3);
-  color: white;
-}
-body.dark .daterangepicker td.end-date {
-  background-color: #5149e5;
-}
-body.dark .daterangepicker select {
-  background-color: #3b3b41;
-  color: #a3a3a3;
-  border-color: #5f5f69;
-}
-body.dark .clockpicker-plate {
-  background-color: #3b3b41;
-  border-color: #3b3b41;
-}
-body.dark .clockpicker-tick {
-  color: #a3a3a3;
-}
-body.dark .img-thumbnail {
-  background-color: #323236;
-  border-color: #47474e;
-}
-body.dark .avatar .avatar-text {
-  background: #47474e;
-}
-body.dark .avatar.avatar-dark .avatar-text {
-  background-color: #1e1e21 !important;
-}
-body.dark .demo-icon-list:hover {
-  background: #3b3b41;
-}
-body.dark .jqvmap-region {
-  fill: rgba(81, 73, 229, 0.3);
-}
-body.dark .jqvmap-region:hover {
-  fill: #5149e5;
-}
-body.dark .list-group-item {
-  color: #a3a3a3;
-  background-color: #323236;
-  border-color: #47474e;
-}
-body.dark .list-group-item.active {
-  background-color: #5149e5;
-  color: rgba(255, 255, 255, 0.85);
-}
-body.dark .list-group-item.active:hover {
-  color: rgba(255, 255, 255, 0.85);
-}
-body.dark .list-group-item-action {
-  color: #a3a3a3;
-}
-body.dark .list-group-item-action:hover {
-  color: #d7d7d7;
-}
-body.dark .mark, body.dark mark {
-  background-color: #47474e;
-  color: #a3a3a3;
-}
-body.dark .bg-image {
-  color: white;
-}
-body.dark .bg-image:before {
-  background: rgba(0, 0, 0, 0.4);
-}
-body.dark .row-vertical-border [class*=col-]:not(:last-child) {
-  border-right-color: #47474e;
-}
-body.dark.rtl .row-vertical-border [class*=col-]:not(:last-child) {
-  border-left-color: #47474e;
-}
-body.dark ::-moz-selection {
-  background-color: #5149e5;
-  color: white;
-}
-body.dark ::selection {
-  background-color: #5149e5;
-  color: white;
-}
-body.dark .apexcharts-svg {
-  background: none !important;
-}
-body.dark .bg-white {
-  background-color: #323236 !important;
-}
-body.dark .ql-snow .ql-stroke {
-  stroke: #a3a3a3;
-}
-body.dark .ql-snow .ql-fill, body.dark .ql-snow .ql-stroke.ql-fill {
-  fill: #a3a3a3;
-}
-body.dark .ql-snow.ql-toolbar button:hover .ql-stroke, body.dark .ql-snow .ql-toolbar button:hover .ql-stroke, body.dark .ql-snow.ql-toolbar button:focus .ql-stroke, body.dark .ql-snow .ql-toolbar button:focus .ql-stroke, body.dark .ql-snow.ql-toolbar button.ql-active .ql-stroke, body.dark .ql-snow .ql-toolbar button.ql-active .ql-stroke, body.dark .ql-snow.ql-toolbar .ql-picker-label:hover .ql-stroke, body.dark .ql-snow .ql-toolbar .ql-picker-label:hover .ql-stroke, body.dark .ql-snow.ql-toolbar .ql-picker-label.ql-active .ql-stroke, body.dark .ql-snow .ql-toolbar .ql-picker-label.ql-active .ql-stroke, body.dark .ql-snow.ql-toolbar .ql-picker-item:hover .ql-stroke, body.dark .ql-snow .ql-toolbar .ql-picker-item:hover .ql-stroke, body.dark .ql-snow.ql-toolbar .ql-picker-item.ql-selected .ql-stroke, body.dark .ql-snow .ql-toolbar .ql-picker-item.ql-selected .ql-stroke, body.dark .ql-snow.ql-toolbar button:hover .ql-stroke-miter, body.dark .ql-snow .ql-toolbar button:hover .ql-stroke-miter, body.dark .ql-snow.ql-toolbar button:focus .ql-stroke-miter, body.dark .ql-snow .ql-toolbar button:focus .ql-stroke-miter, body.dark .ql-snow.ql-toolbar button.ql-active .ql-stroke-miter, body.dark .ql-snow .ql-toolbar button.ql-active .ql-stroke-miter, body.dark .ql-snow.ql-toolbar .ql-picker-label:hover .ql-stroke-miter, body.dark .ql-snow .ql-toolbar .ql-picker-label:hover .ql-stroke-miter, body.dark .ql-snow.ql-toolbar .ql-picker-label.ql-active .ql-stroke-miter, body.dark .ql-snow .ql-toolbar .ql-picker-label.ql-active .ql-stroke-miter, body.dark .ql-snow.ql-toolbar .ql-picker-item:hover .ql-stroke-miter, body.dark .ql-snow .ql-toolbar .ql-picker-item:hover .ql-stroke-miter, body.dark .ql-snow.ql-toolbar .ql-picker-item.ql-selected .ql-stroke-miter, body.dark .ql-snow .ql-toolbar .ql-picker-item.ql-selected .ql-stroke-miter {
-  stroke: #d7d7d7;
-}
-body.dark .ql-snow.ql-toolbar button:hover .ql-fill, body.dark .ql-snow .ql-toolbar button:hover .ql-fill, body.dark .ql-snow.ql-toolbar button:focus .ql-fill, body.dark .ql-snow .ql-toolbar button:focus .ql-fill, body.dark .ql-snow.ql-toolbar button.ql-active .ql-fill, body.dark .ql-snow .ql-toolbar button.ql-active .ql-fill, body.dark .ql-snow.ql-toolbar .ql-picker-label:hover .ql-fill, body.dark .ql-snow .ql-toolbar .ql-picker-label:hover .ql-fill, body.dark .ql-snow.ql-toolbar .ql-picker-label.ql-active .ql-fill, body.dark .ql-snow .ql-toolbar .ql-picker-label.ql-active .ql-fill, body.dark .ql-snow.ql-toolbar .ql-picker-item:hover .ql-fill, body.dark .ql-snow .ql-toolbar .ql-picker-item:hover .ql-fill, body.dark .ql-snow.ql-toolbar .ql-picker-item.ql-selected .ql-fill, body.dark .ql-snow .ql-toolbar .ql-picker-item.ql-selected .ql-fill, body.dark .ql-snow.ql-toolbar button:hover .ql-stroke.ql-fill, body.dark .ql-snow .ql-toolbar button:hover .ql-stroke.ql-fill, body.dark .ql-snow.ql-toolbar button:focus .ql-stroke.ql-fill, body.dark .ql-snow .ql-toolbar button:focus .ql-stroke.ql-fill, body.dark .ql-snow.ql-toolbar button.ql-active .ql-stroke.ql-fill, body.dark .ql-snow .ql-toolbar button.ql-active .ql-stroke.ql-fill, body.dark .ql-snow.ql-toolbar .ql-picker-label:hover .ql-stroke.ql-fill, body.dark .ql-snow .ql-toolbar .ql-picker-label:hover .ql-stroke.ql-fill, body.dark .ql-snow.ql-toolbar .ql-picker-label.ql-active .ql-stroke.ql-fill, body.dark .ql-snow .ql-toolbar .ql-picker-label.ql-active .ql-stroke.ql-fill, body.dark .ql-snow.ql-toolbar .ql-picker-item:hover .ql-stroke.ql-fill, body.dark .ql-snow .ql-toolbar .ql-picker-item:hover .ql-stroke.ql-fill, body.dark .ql-snow.ql-toolbar .ql-picker-item.ql-selected .ql-stroke.ql-fill, body.dark .ql-snow .ql-toolbar .ql-picker-item.ql-selected .ql-stroke.ql-fill {
-  fill: #d7d7d7;
-}
-body.dark .email-list .list-group .list-group-item.active, body.dark .todo-list .list-group .list-group-item.active {
-  background-color: #323236;
-  color: inherit;
-}
-body.dark .nav-link {
-  color: #a3a3a3;
-}
-body.dark .nav-link:hover {
-  color: #d7d7d7;
-}
-body.dark .irs--round .irs-min, body.dark .irs--round .irs-max {
-  color: inherit;
-}
-body.dark .irs--round .irs-line {
-  background-color: #47474e;
-}
-body.dark .irs--round .irs-handle {
-  background-color: #47474e;
-}
-body.dark .swal2-popup {
-  background-color: #323236;
-}
-body.dark .swal2-title, body.dark .swal2-content {
-  color: #a3a3a3;
-}
-body.dark .swal2-footer {
-  border-top-color: #47474e;
-}
-body.dark .swal2-modal .swal2-actions .swal2-deny {
-  background-color: #47474e;
-  color: #a3a3a3;
-}
-body.dark .form-range::-webkit-slider-runnable-track {
-  background-color: #47474e;
-}
-body.dark .introjs-tooltip {
-  background-color: #323236;
-}
-body.dark .introjs-arrow.top {
-  border-bottom-color: #323236;
-}
-body.dark .introjs-arrow.bottom {
-  border-top-color: #323236;
-}
-body.dark .introjs-arrow.right {
-  border-left-color: #323236;
-}
-body.dark .introjs-arrow.left {
-  border-right-color: #323236;
-}
-body.dark .introjs-tooltipbuttons {
-  border-top-color: #47474e;
-}
-body.dark .introjs-button {
-  background-color: #3b3b41;
-  border-color: #47474e;
-}
-body.dark code {
-  color: #f371b2;
-}
-@media (max-width: 1000px) {
-  body.dark .chat-block .chat-content.chat-mobile-open {
-    background-color: #3b3b41;
-  }
-}
-
-@media (max-width: 1300px) {
-  .chat-block .chat-sidebar {
-    width: 350px;
-  }
-}
-@media (max-width: 1200px) {
-  .header .menu-toggle-btn {
-    display: block;
-  }
-  .header .header-mobile-buttons a.header-menu-btn {
-    display: block;
-  }
-  .header .header-menu {
-    opacity: 0;
-    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
-    position: fixed;
-    left: -110%;
-    top: 0;
-    bottom: 0;
-    overflow: auto;
-    width: 350px;
-    background: white;
-    z-index: 999;
-    padding: 0 30px;
-    transition: all 0.2s;
-  }
-  .header .header-menu-header {
-    display: flex !important;
-  }
-  .header .header-menu-header img {
-    width: 100px;
-  }
-  .header .header-menu .dropdown {
-    display: block;
-  }
-  .header .header-menu ul.navbar-nav {
-    display: block;
-    margin-left: 0;
-  }
-  .header .header-menu ul.navbar-nav li a {
-    color: black;
-    padding: 15px 30px !important;
-    height: auto !important;
-    margin-left: 0 !important;
-    border-right: 4px solid transparent;
-    border-left: 4px solid transparent;
-    border-radius: 5rem;
-  }
-  .header .header-menu ul.navbar-nav li a:before {
-    display: none !important;
-  }
-  .header .header-menu ul.navbar-nav li a .sub-menu-arrow {
-    margin-left: auto !important;
-  }
-  .header .header-menu ul.navbar-nav li a:hover {
-    color: black;
-    background: #f2f2f2 !important;
-  }
-  .header .header-menu ul.navbar-nav li a.active {
-    background: rgba(81, 73, 229, 0.15) !important;
-    color: #5149e5 !important;
-    border-left-color: #5149e5;
-    border-right-color: #5149e5;
-  }
-  .header .header-menu ul.navbar-nav li .nav-sub-menu {
-    visibility: visible !important;
-    opacity: 1 !important;
-    width: auto !important;
-    position: static !important;
-    padding: 0 !important;
-    margin-top: 0 !important;
     display: none;
-    transform: scale(1) !important;
-  }
-  .header .header-menu ul.navbar-nav li .nav-sub-menu:after {
-    display: none !important;
-  }
-  .header .header-menu ul.navbar-nav li .nav-sub-menu ul {
-    box-shadow: none !important;
-    border: none !important;
-    padding: 0 !important;
-    border-radius: 0 !important;
-  }
-  .header .header-menu ul.navbar-nav li .nav-sub-menu ul li a {
-    padding-left: 58px !important;
-  }
-  .header .header-menu ul.navbar-nav li .nav-sub-menu ul li ul li a {
-    padding-left: 70px !important;
-  }
-  .header .header-menu ul.navbar-nav li.open > .nav-sub-menu {
+}
+
+body.hidden-menu .header .logos {
     display: block;
-  }
-  .header .header-menu.open {
-    left: 0;
-    opacity: 1;
-  }
-  .sidebar {
-    z-index: 1001;
-  }
-  .page-header > .container, .bg-image > .container {
-    max-width: 100% !important;
-    padding: 0;
-  }
-  .layout-wrapper {
-    margin-left: 0;
-  }
-  .layout-wrapper .content > .container {
-    max-width: 100% !important;
-    padding: 0;
-  }
-  body.rtl .layout-wrapper {
-    margin-left: 0;
-    margin-right: 0;
-  }
-  .content-footer {
-    margin-left: 0 !important;
-    margin-right: 0 !important;
-    padding-left: 20px !important;
-  }
-  .menu {
+}
+
+body.hidden-menu .header .menu-toggle-btn {
+    display: block;
+}
+
+body.hidden-menu .menu {
+    display: none;
     box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
     width: 350px;
     position: fixed;
@@ -14794,659 +3613,2153 @@ body.dark code {
     z-index: 9998 !important;
     transition: all 0.2s;
     background-color: white;
-  }
-  .menu .menu-close-btn {
+}
+
+body.hidden-menu .menu .menu-close-btn {
     display: block;
-  }
-  .menu.open {
+}
+
+body.hidden-menu .menu .dropdown {
+    background-color: #f5f4fe;
+}
+
+body.hidden-menu .menu.open {
     left: 0 !important;
     opacity: 1;
-  }
-  .menu-body {
-    overflow: auto;
-    border-radius: 0 !important;
-  }
-  .menu-body .dropdown {
-    background-color: #f5f4fe;
-  }
-  .menu-body ul li > a.active .nav-link-icon {
-    background-color: white;
-  }
-  body.rtl .menu {
-    left: auto !important;
-    right: -110% !important;
-  }
-  body.rtl .menu.open {
-    right: 0 !important;
-  }
-  body.header-menu .menu-body ul li a {
-    display: flex;
-    align-items: center;
-    padding: 10px 20px;
-  }
-  body.header-menu .menu-body ul li a .nav-link-icon {
-    margin-right: 0.8rem;
-  }
-  body.header-menu .menu-body ul li a .sub-menu-arrow {
-    margin-left: auto;
-    font-size: 10px;
-  }
-  body.header-menu .menu-body ul li a + ul li a {
-    padding-left: 50px !important;
-  }
-  .sidebar a.btn-sidebar-close {
-    display: flex !important;
-  }
 }
-@media (max-width: 1000px) {
-  .chat-block .chat-content {
-    display: none;
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-bottom: 20px;
-  }
-  .chat-block .chat-content .chat-header {
-    padding: 0.5rem 1.5rem;
-  }
-  .chat-block .chat-content .mobile-chat-close-btn {
-    display: block;
-  }
-  .chat-block .chat-content.chat-mobile-open {
-    display: flex;
+
+body.hidden-menu .menu-body {
+    overflow: auto;
+    border-top-left-radius: 0;
+}
+
+body.hidden-menu .menu-body ul li>a.active .nav-link-icon {
     background-color: white;
+}
+
+body.hidden-menu .layout-wrapper {
+    margin-left: 0;
+}
+
+.layout-wrapper {
+    display: flex;
+    flex-direction: column;
+    margin-left: 350px;
+    min-height: 100vh;
+}
+
+.layout-wrapper>.content {
+    flex: 1;
+    padding: 1.5rem;
+}
+
+body.dark {
+    background-color: #3b3b41;
+    color: #a3a3a3;
+    /* Overrides the border radius setting in the theme. */
+    --ck-border-radius: 4px;
+    /* Overrides the default font size in the theme. */
+    --ck-font-size-base: 14px;
+    /* Helper variables to avoid duplication in the colors. */
+    --ck-custom-background: hsl(270, 1%, 29%);
+    --ck-custom-foreground: hsl(255, 3%, 18%);
+    --ck-custom-border: hsl(300, 1%, 22%);
+    --ck-custom-white: hsl(0, 0%, 80%);
+    /* -- Overrides generic colors. ------------------------------------------------------------- */
+    --ck-color-base-foreground: var(--ck-custom-background);
+    --ck-color-focus-border: hsl(208, 90%, 62%);
+    --ck-color-text: hsl(0, 0%, 98%);
+    --ck-color-shadow-drop: hsla(0, 0%, 0%, 0.2);
+    --ck-color-shadow-inner: hsla(0, 0%, 0%, 0.1);
+    /* -- Overrides the default .ck-button class colors. ---------------------------------------- */
+    --ck-color-button-default-background: var(--ck-custom-background);
+    --ck-color-button-default-hover-background: hsl(270, 1%, 22%);
+    --ck-color-button-default-active-background: hsl(270, 2%, 20%);
+    --ck-color-button-default-active-shadow: hsl(270, 2%, 23%);
+    --ck-color-button-default-disabled-background: var(--ck-custom-background);
+    --ck-color-button-on-background: var(--ck-custom-foreground);
+    --ck-color-button-on-hover-background: hsl(255, 4%, 16%);
+    --ck-color-button-on-active-background: hsl(255, 4%, 14%);
+    --ck-color-button-on-active-shadow: hsl(240, 3%, 19%);
+    --ck-color-button-on-disabled-background: var(--ck-custom-foreground);
+    --ck-color-button-action-background: hsl(168, 76%, 42%);
+    --ck-color-button-action-hover-background: hsl(168, 76%, 38%);
+    --ck-color-button-action-active-background: hsl(168, 76%, 36%);
+    --ck-color-button-action-active-shadow: hsl(168, 75%, 34%);
+    --ck-color-button-action-disabled-background: hsl(168, 76%, 42%);
+    --ck-color-button-action-text: var(--ck-custom-white);
+    --ck-color-button-save: hsl(120, 100%, 46%);
+    --ck-color-button-cancel: hsl(15, 100%, 56%);
+    /* -- Overrides the default .ck-dropdown class colors. -------------------------------------- */
+    --ck-color-dropdown-panel-background: var(--ck-custom-background);
+    --ck-color-dropdown-panel-border: var(--ck-custom-foreground);
+    /* -- Overrides the default .ck-splitbutton class colors. ----------------------------------- */
+    --ck-color-split-button-hover-background: var(--ck-color-button-default-hover-background);
+    --ck-color-split-button-hover-border: var(--ck-custom-foreground);
+    /* -- Overrides the default .ck-input class colors. ----------------------------------------- */
+    --ck-color-input-background: var(--ck-custom-background);
+    --ck-color-input-border: hsl(257, 3%, 43%);
+    --ck-color-input-text: hsl(0, 0%, 98%);
+    --ck-color-input-disabled-background: hsl(255, 4%, 21%);
+    --ck-color-input-disabled-border: hsl(250, 3%, 38%);
+    --ck-color-input-disabled-text: hsl(0, 0%, 78%);
+    /* -- Overrides the default .ck-labeled-field-view class colors. ---------------------------- */
+    --ck-color-labeled-field-label-background: var(--ck-custom-background);
+    /* -- Overrides the default .ck-list class colors. ------------------------------------------ */
+    --ck-color-list-background: var(--ck-custom-background);
+    --ck-color-list-button-hover-background: var(--ck-color-base-foreground);
+    --ck-color-list-button-on-background: var(--ck-color-base-active);
+    --ck-color-list-button-on-background-focus: var(--ck-color-base-active-focus);
+    --ck-color-list-button-on-text: var(--ck-color-base-background);
+    /* -- Overrides the default .ck-balloon-panel class colors. --------------------------------- */
+    --ck-color-panel-background: var(--ck-custom-background);
+    --ck-color-panel-border: var(--ck-custom-border);
+    /* -- Overrides the default .ck-toolbar class colors. --------------------------------------- */
+    --ck-color-toolbar-background: var(--ck-custom-background);
+    --ck-color-toolbar-border: var(--ck-custom-border);
+    /* -- Overrides the default .ck-tooltip class colors. --------------------------------------- */
+    --ck-color-tooltip-background: hsl(252, 7%, 14%);
+    --ck-color-tooltip-text: hsl(0, 0%, 93%);
+    /* -- Overrides the default colors used by the ckeditor5-image package. --------------------- */
+    --ck-color-image-caption-background: hsl(0, 0%, 97%);
+    --ck-color-image-caption-text: hsl(0, 0%, 20%);
+    /* -- Overrides the default colors used by the ckeditor5-widget package. -------------------- */
+    --ck-color-widget-blurred-border: hsl(0, 0%, 87%);
+    --ck-color-widget-hover-border: hsl(43, 100%, 68%);
+    --ck-color-widget-editable-focus-background: var(--ck-custom-white);
+    /* -- Overrides the default colors used by the ckeditor5-link package. ---------------------- */
+    --ck-color-link-default: hsl(190, 100%, 75%);
+    --ck-color-base-background: $ dark-mode-color-1;
+}
+
+body.dark .preloader {
+    background-color: #3b3b41;
+}
+
+body.dark .preloader .preloader-icon {
+    border-color: #3b3b41;
+    border-top-color: #5149e5;
+}
+
+body.dark .pagination .page-item:not(.active) .page-link {
+    background-color: #323236;
+    border-color: #47474e;
+}
+
+body.dark .progress {
+    background-color: #47474e;
+}
+
+body.dark .border {
+    border-color: #47474e !important;
+}
+
+body.dark .border-top {
+    border-top-color: #47474e !important;
+}
+
+body.dark .border-bottom {
+    border-bottom-color: #47474e !important;
+}
+
+body.dark .border-end {
+    border-right-color: #47474e !important;
+}
+
+body.dark .border-start {
+    border-left-color: #47474e !important;
+}
+
+body.dark .dropdown-menu {
+    background-color: #47474e;
+    color: inherit;
+}
+
+body.dark .dropdown-menu .dropdown-header {
+    border-bottom-color: #5f5f69;
+}
+
+body.dark .dropdown-menu .dropdown-divider {
+    border-top-color: #5f5f69;
+    opacity: 1;
+}
+
+body.dark .dropdown-menu .dropdown-item {
+    color: #a3a3a3;
+}
+
+body.dark .dropdown-menu .dropdown-item:hover {
+    color: #d7d7d7;
+}
+
+body.dark .dropdown-menu .list-group-item {
+    background-color: #47474e;
+}
+
+body.dark .dropdown-menu .border-top {
+    border-top-color: #5f5f69 !important;
+}
+
+body.dark .dropdown-menu .border-bottom {
+    border-bottom-color: #5f5f69 !important;
+}
+
+body.dark .wizard>.steps .disabled a,
+body.dark .wizard>.steps .disabled a:hover,
+body.dark .wizard>.steps .disabled a:active {
+    background-color: #323236;
+}
+
+body.dark .wizard .wizard-index {
+    background-color: #47474e;
+}
+
+body.dark .wizard .current .wizard-index,
+body.dark .wizard .done .wizard-index {
+    background-color: rgba(255, 255, 255, 0.15);
+}
+
+body.dark .wizard>.actions a,
+body.dark .wizard>.actions a:active,
+body.dark .wizard>.actions a:hover {
+    color: white !important;
+}
+
+body.dark .wizard>.actions .disabled a,
+body.dark .wizard>.actions .disabled a:hover,
+body.dark .wizard>.actions .disabled a:active {
+    color: #aaaaaa !important;
+    background-color: #47474e !important;
+}
+
+body.dark.auth {
+    background-color: #3b3b41;
+}
+
+body.dark.auth .social-links a {
+    border-color: #47474e;
+    color: #a3a3a3;
+}
+
+body.dark.auth .social-links a:hover {
+    color: #d7d7d7;
+    border-color: #5149e5;
+}
+
+body.dark .chat-block .chat-sidebar .chat-sidebar-content .list-group .list-group-item {
+    background-color: #323236;
+}
+
+body.dark .chat-block .chat-sidebar .chat-sidebar-content .list-group .list-group-item:not(.active):hover {
+    background-color: #2b2b2e;
+}
+
+body.dark .chat-block .chat-sidebar .chat-sidebar-content .list-group .list-group-item.active {
+    color: inherit;
+}
+
+body.dark .chat-block .chat-content .messages .message-item .message-item-content {
+    background-color: #323236;
+}
+
+body.dark .chat-block .chat-content .messages .message-item.me .message-item-content {
+    background: rgba(81, 73, 229, 0.15);
+    color: #d7d7d7;
+}
+
+body.dark .chat-block .chat-content .messages .message-item.message-item-divider:after,
+body.dark .chat-block .chat-content .messages .message-item.message-item-divider:before {
+    background-color: #5f5f69;
+}
+
+body.dark .form-switch .form-check-input {
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='#47474e'/%3E%3C/svg%3E");
+}
+
+body.dark .form-switch .form-check-input:checked {
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='rgba(255, 255, 255, 0.5)'/%3E%3C/svg%3E");
+}
+
+body.dark .form-check-input:not(:checked) {
+    background-color: #3b3b41;
+    border-color: #53535c;
+}
+
+body.dark .form-check-input:checked[type=radio] {
+    background-image: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='2' fill='%23323236'/></svg>");
+}
+
+body.dark .form-control-plaintext {
+    color: #a3a3a3;
+}
+
+body.dark .form-control::-webkit-file-upload-button,
+.swal2-modal body.dark .swal2-input::-webkit-file-upload-button,
+body.dark .swal2-modal .swal2-input::-webkit-file-upload-button {
+    background-color: #3b3b41;
+    color: #a3a3a3;
+}
+
+body.dark .form-control:hover:not(:disabled):not([readonly])::-webkit-file-upload-button,
+.swal2-modal body.dark .swal2-input:hover:not(:disabled):not([readonly])::-webkit-file-upload-button,
+body.dark .swal2-modal .swal2-input:hover:not(:disabled):not([readonly])::-webkit-file-upload-button {
+    background-color: #3b3b41;
+}
+
+body.dark .form-control,
+.swal2-modal body.dark .swal2-input,
+body.dark .swal2-modal .swal2-input,
+body.dark .form-select {
+    background-color: #323236;
+    color: #a3a3a3;
+    border-color: #47474e;
+}
+
+body.dark .form-select {
+    background-image: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='%237a7a7a' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/></svg>");
+}
+
+body.dark .input-group-text {
+    border-color: #47474e;
+    color: #a3a3a3;
+    background-color: #47474e;
+}
+
+body.dark .table {
+    color: #a3a3a3;
+}
+
+body.dark .table.table-custom tbody tr {
+    background-color: #323236;
+}
+
+body.dark .table.table-custom tbody tr:not(.tr-selected) td {
+    border-top-color: #323236;
+    border-bottom-color: #323236;
+}
+
+body.dark .table.table-custom tbody tr:not(.tr-selected) td:first-child {
+    border-left-color: #323236;
+}
+
+body.dark .table.table-custom tbody tr:not(.tr-selected) td:last-child {
+    border-right-color: #323236;
+}
+
+body.dark .table> :not(caption)>*>* {
+    border-bottom-color: #47474e;
+}
+
+body.dark .table-striped>tbody>tr:nth-of-type(odd) {
+    color: #a3a3a3;
+}
+
+body.dark .table-hover>tbody>tr:hover {
+    color: #a3a3a3;
+}
+
+body.dark .table> :not(:last-child)> :last-child>* {
+    border-bottom-color: #47474e;
+}
+
+body.dark .table-active {
+    color: #a3a3a3;
+}
+
+body.dark tbody,
+body.dark td,
+body.dark tfoot,
+body.dark th,
+body.dark thead,
+body.dark tr {
+    border-color: #47474e;
+}
+
+body.dark .table-light {
+    --bs-table-bg: #47474e;
+    color: #a3a3a3;
+}
+
+body.dark .card .table.table-custom tbody tr:not(.tr-selected) td {
+    border-top-color: #47474e;
+    border-bottom-color: #47474e;
+}
+
+body.dark .card .table.table-custom tbody tr:not(.tr-selected) td:first-child {
+    border-left-color: #47474e;
+}
+
+body.dark .card .table.table-custom tbody tr:not(.tr-selected) td:last-child {
+    border-right-color: #47474e;
+}
+
+body.dark .table .form-check-input:not(:checked) {
+    background-color: #323236;
+    border-color: #4b4b50;
+}
+
+body.dark .header {
+    background-color: #3b3b41;
+}
+
+body.dark .header .search-form .input-group {
+    background-color: #323236;
+}
+
+body.dark .header .search-form .btn:hover,
+body.dark .header .search-form .btn:active {
+    color: #a3a3a3 !important;
+}
+
+body.dark .header .search-form .form-control::-moz-placeholder,
+body.dark .header .search-form .swal2-modal .swal2-input::-moz-placeholder,
+.swal2-modal body.dark .header .search-form .swal2-input::-moz-placeholder {
+    color: rgba(255, 255, 255, 0.25);
+}
+
+body.dark .header .search-form .form-control::placeholder,
+body.dark .header .search-form .swal2-modal .swal2-input::placeholder,
+.swal2-modal body.dark .header .search-form .swal2-input::placeholder {
+    color: rgba(255, 255, 255, 0.25);
+}
+
+body.dark .header .header-menu .dropdown {
+    background-color: #323236;
+}
+
+body.dark .header .header-menu ul.navbar-nav li .nav-sub-menu>ul {
+    background-color: #47474e;
+}
+
+body.dark .header .header-menu ul.navbar-nav li a {
+    color: #a3a3a3 !important;
+}
+
+body.dark .header .header-menu ul.navbar-nav li a.active {
+    color: #d7d7d7 !important;
+}
+
+body.dark .header .header-menu ul.navbar-nav li a:hover {
+    color: #d7d7d7 !important;
+}
+
+body.dark .header .header-menu ul.navbar-nav li.open>a {
+    color: #d7d7d7 !important;
+}
+
+body.dark .header .menu-toggle-btn a,
+body.dark .header .header-mobile-buttons a {
+    color: #a3a3a3;
+}
+
+body.dark .header .menu-toggle-btn a:hover,
+body.dark .header .menu-toggle-btn a:focus,
+body.dark .header .header-mobile-buttons a:hover,
+body.dark .header .header-mobile-buttons a:focus {
+    color: #d7d7d7;
+}
+
+body.dark .header ul.navbar-nav li.nav-item a.nav-link {
+    color: #a3a3a3;
+}
+
+@media (max-width: 1200px) {
+    body.dark .header .header-menu {
+        background-color: #3b3b41;
+    }
+
+    body.dark .header .header-menu .header-menu-close {
+        background-color: #3b3b41;
+    }
+
+    body.dark .header .header-menu .dropdown>a {
+        background-color: #323236;
+    }
+
+    body.dark .header .header-menu ul.navbar-nav li a:hover {
+        background: none !important;
+        color: white;
+    }
+
+    body.dark .header .header-menu ul.navbar-nav li .nav-sub-menu>ul {
+        background: none;
+    }
+
+    body.dark .header .header-menu ul.navbar-nav li .nav-sub-menu>ul li a {
+        color: #a3a3a3;
+    }
+}
+
+@media (max-width: 768px) {
+    body.dark .header .search-form .input-group {
+        background-color: #3b3b41;
+    }
+
+    body.dark .header .header-bar {
+        background-color: #323236;
+    }
+}
+
+body.dark .menu-body .dropdown {
+    background-color: #323236;
+}
+
+body.dark .menu-body ul li a {
+    color: #a3a3a3;
+}
+
+body.dark .menu-body ul li a.active {
+    color: #d7d7d7;
+}
+
+body.dark .menu-body ul li a.active .nav-link-icon {
+    background-color: #3b3b41;
+}
+
+body.dark .menu-body ul li a:hover {
+    color: #d7d7d7;
+}
+
+body.dark.hidden-menu .menu {
+    background-color: #3b3b41;
+}
+
+body.dark.hidden-menu .menu-header .menu-close-btn {
+    background-color: #3b3b41;
+}
+
+@media (max-width: 1200px) {
+    body.dark .menu {
+        background-color: #3b3b41;
+    }
+
+    body.dark .menu-header .menu-close-btn {
+        background-color: #3b3b41;
+    }
+}
+
+body.dark .breadcrumb-item+.breadcrumb-item:before {
+    color: #a3a3a3;
+}
+
+body.dark .card.widget .card-header {
+    background-color: #3b3b41;
+}
+
+body.dark .card.widget .card-header+.card-body {
+    background-color: #323236;
+}
+
+body.dark .card:not(.widget) {
+    background-color: #323236;
+}
+
+body.dark .card .form-check-input:not(:checked) {
+    background-color: #323236;
+}
+
+body.dark .card .card {
+    border-color: transparent;
+    border: 1px solid #47474e;
+}
+
+body.dark .card .avatar {
+    border-color: #323236;
+}
+
+body.dark .card .avatar:before {
+    border-color: #323236;
+}
+
+body.dark .card .avatar-group .avatar {
+    border-color: #323236;
+}
+
+body.dark .card-header {
+    border-bottom-color: #47474e;
+}
+
+body.dark .card-footer {
+    border-top-color: #47474e;
+}
+
+body.dark .avatar {
+    border-color: #323236;
+}
+
+body.dark .avatar:before {
+    border-color: #323236;
+}
+
+body.dark .avatar-group .avatar {
+    border-color: #323236;
+}
+
+body.dark .accordion-button {
+    color: inherit;
+    border-color: #47474e;
+}
+
+body.dark .accordion-button:not(.collapsed) {
+    background-color: rgba(81, 73, 229, 0.15);
+    color: #d7d7d7;
+}
+
+body.dark .accordion-button:after {
+    background-image: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='%237a7a7a' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/></svg>");
+}
+
+body.dark .accordion-collapse {
+    border-color: #47474e;
+}
+
+body.dark .sidebar {
+    background-color: #323236;
+}
+
+body.dark .sidebar .sidebar-header {
+    border-bottom-color: #47474e;
+}
+
+body.dark .sidebar [data-sidebar-close] {
+    color: #a3a3a3;
+}
+
+body.dark .modal-content {
+    background-color: #323236;
+}
+
+body.dark .modal-content .avatar-group .avatar {
+    border-color: #323236;
+}
+
+body.dark .modal-header {
+    border-bottom-color: #47474e;
+}
+
+body.dark .modal-footer {
+    border-top-color: #47474e;
+}
+
+body.dark .btn-close {
+    background: transparent url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='#a3a3a3' d='M.293.293a1 1 0 011.414 0L8 6.586 14.293.293a1 1 0 111.414 1.414L9.414 8l6.293 6.293a1 1 0 01-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 01-1.414-1.414L6.586 8 .293 1.707a1 1 0 010-1.414z'/></svg>") 50%/1em auto no-repeat;
+}
+
+body.dark .toast {
+    background-color: #323236;
+}
+
+body.dark .toast-header {
+    background-color: #3e3e43;
+    color: inherit;
+}
+
+body.dark .popover {
+    background-color: #47474e;
+}
+
+body.dark .popover-header {
+    background-color: #47474e;
+    border-bottom-color: #5f5f69;
+}
+
+body.dark .popover-body {
+    color: inherit;
+}
+
+body.dark .bs-popover-auto[data-popper-placement^=left]>.popover-arrow:after,
+body.dark .bs-popover-start>.popover-arrow:after {
+    border-left-color: #47474e;
+}
+
+body.dark .bs-popover-auto[data-popper-placement^=right]>.popover-arrow:after,
+body.dark .bs-popover-end>.popover-arrow:after {
+    border-right-color: #47474e;
+}
+
+body.dark .bs-popover-auto[data-popper-placement^=top]>.popover-arrow:after,
+body.dark .bs-popover-top>.popover-arrow:after {
+    border-top-color: #47474e;
+}
+
+body.dark .bs-popover-auto[data-popper-placement^=bottom]>.popover-arrow:after,
+body.dark .bs-popover-bottom>.popover-arrow:after {
+    border-bottom-color: #47474e;
+}
+
+body.dark a,
+body.dark .btn {
+    color: #a3a3a3;
+}
+
+body.dark a:hover,
+body.dark .btn:hover {
+    color: #d7d7d7;
+}
+
+body.dark .btn.btn-light {
+    color: #a3a3a3 !important;
+    background-color: #47474e;
+    border-color: #47474e;
+}
+
+body.dark .btn.btn-light:hover {
+    color: #d7d7d7 !important;
+}
+
+body.dark .btn.btn-outline-light {
+    color: #a3a3a3 !important;
+    border-color: #47474e;
+}
+
+body.dark .btn.btn-outline-light:hover {
+    background-color: #47474e;
+    color: #d7d7d7 !important;
+}
+
+body.dark .btn.btn-outline-dark {
+    border-color: #1e1e21;
+    color: #a3a3a3 !important;
+}
+
+body.dark .btn.btn-outline-dark:hover {
+    background-color: #1e1e21 !important;
+}
+
+body.dark .btn-dark {
+    background-color: #1e1e21 !important;
+    border-color: #1e1e21 !important;
+}
+
+body.dark.doc .menu {
+    background-color: #323236;
+}
+
+body.dark .demo-code-preview {
+    border-top-color: #47474e;
+}
+
+body.dark #TableOfContents ul li a:hover {
+    color: #d7d7d7;
+}
+
+body.dark .nav-tabs {
+    border-bottom-color: #47474e;
+}
+
+body.dark .nav-tabs .nav-item.show .nav-link,
+body.dark .nav-tabs .nav-link.active {
+    background-color: #323236;
+    border-color: #47474e;
+    border-bottom-color: transparent;
+    color: #d7d7d7;
+}
+
+body.dark .nav-tabs .nav-link:focus,
+body.dark .nav-tabs .nav-link:hover {
+    border-color: #47474e;
+}
+
+body.dark code[class*=language-],
+body.dark pre[class*=language-] {
+    color: #d7d7d7;
+}
+
+body.dark .token.operator,
+body.dark .token.entity,
+body.dark .token.url,
+body.dark .language-css .token.string,
+body.dark .style .token.string {
+    background: none;
+}
+
+body.dark .token.property,
+body.dark .token.tag,
+body.dark .token.boolean,
+body.dark .token.number,
+body.dark .token.constant,
+body.dark .token.symbol,
+body.dark .token.deleted {
+    color: #fa50ae;
+}
+
+body.dark .dd-handle {
+    background: #323236;
+    border-color: #3b3b41;
+    color: #a3a3a3;
+}
+
+body.dark .dd-item>button {
+    color: #a3a3a3;
+}
+
+body.dark .dd-empty,
+body.dark .dd-placeholder {
+    background: #323236;
+}
+
+body.dark .slick-wrapper .slick-next:before,
+body.dark .slick-wrapper .slick-prev:before {
+    color: #a3a3a3;
+}
+
+body.dark .input-group .btn.btn-outline-light {
+    background-color: #323236;
+}
+
+body.dark .input-group .form-control+.btn.btn-outline-light,
+.swal2-modal body.dark .input-group .swal2-input+.btn.btn-outline-light,
+body.dark .input-group .swal2-modal .swal2-input+.btn.btn-outline-light,
+body.dark .swal2-modal .input-group .swal2-input+.btn.btn-outline-light {
+    border-right-color: #47474e;
+}
+
+body.dark .nav.nav-pills .nav-item .nav-link.active {
+    color: #d7d7d7;
+}
+
+body.dark .text-danger {
+    color: #ff7777 !important;
+}
+
+body.dark .text-dark {
+    color: #a3a3a3 !important;
+}
+
+body.dark .text-dark.bg-warning {
+    color: #3b3b41 !important;
+}
+
+body.dark .text-dark.bg-info {
+    color: #3b3b41 !important;
+}
+
+body.dark .bg-warning {
+    color: #3b3b41;
+}
+
+body.dark .bg-info {
+    color: #3b3b41;
+}
+
+body.dark .border-dark {
+    border-color: #1e1e21 !important;
+}
+
+body.dark .bg-dark {
+    background-color: #1e1e21 !important;
+}
+
+body.dark .bg-light {
+    background-color: #3b3b41 !important;
+}
+
+body.dark .bootstrap-tagsinput {
+    background-color: #323236;
+    border-color: #4e4e56;
+}
+
+body.dark .bootstrap-tagsinput input {
+    color: #a3a3a3;
+}
+
+body.dark .dropzone {
+    background-color: #3b3b41;
+    border-color: #4e4e56;
+}
+
+body.dark .ql-container.ql-snow {
+    background-color: #323236;
+    border-color: #4e4e56;
+}
+
+body.dark .ql-editor.ql-blank::before {
+    color: rgba(163, 163, 163, 0.6);
+}
+
+body.dark .select2.select2-container .select2-selection {
+    border-color: #4e4e56;
+}
+
+body.dark .select2-dropdown {
+    background-color: #323236;
+    border-color: #4e4e56;
+}
+
+body.dark .select2-container--default .select2-results__option[aria-selected=true] {
+    background-color: #5149e5;
+    color: white;
+}
+
+body.dark .select2-container--default .select2-selection--multiple,
+body.dark .select2-container--default .select2-selection--single {
+    background-color: #323236;
+}
+
+body.dark .select2-container--default .select2-search--inline .select2-search__field,
+body.dark .select2-container--default .select2-selection--single .select2-selection__rendered {
+    color: #a3a3a3;
+}
+
+body.dark .select2-container--default .select2-search--dropdown .select2-search__field {
+    background-color: #3b3b41;
+    color: #a3a3a3;
+}
+
+body.dark .select2-container--default .select2-selection--multiple .select2-selection__choice {
+    background-color: #47474e;
+}
+
+body.dark .bootstrap-tagsinput .tag {
+    color: #a3a3a3;
+    background-color: #47474e;
+}
+
+body.dark .carousel-control-prev-icon {
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='#323236'%3E%3Cpath d='M11.354 1.646a.5.5 0 010 .708L5.707 8l5.647 5.646a.5.5 0 01-.708.708l-6-6a.5.5 0 010-.708l6-6a.5.5 0 01.708 0z'/%3E%3C/svg%3E");
+}
+
+body.dark .carousel-control-next-icon {
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='#323236'%3E%3Cpath d='M4.646 1.646a.5.5 0 01.708 0l6 6a.5.5 0 010 .708l-6 6a.5.5 0 01-.708-.708L10.293 8 4.646 2.354a.5.5 0 010-.708z'/%3E%3C/svg%3E");
+}
+
+body.dark .daterangepicker {
+    background-color: #47474e;
+    border-color: #47474e;
+}
+
+body.dark .daterangepicker .calendar-table .next span,
+body.dark .daterangepicker .calendar-table .prev span {
+    border-color: #a3a3a3;
+}
+
+body.dark .daterangepicker .drp-buttons {
+    border-top-color: #5f5f69;
+}
+
+body.dark .daterangepicker .calendar-table {
+    background-color: #47474e;
+    border-color: #47474e;
+}
+
+body.dark .daterangepicker td.off,
+body.dark .daterangepicker td.off.end-date,
+body.dark .daterangepicker td.off.in-range,
+body.dark .daterangepicker td.off.start-date {
+    background-color: #47474e;
+}
+
+body.dark .daterangepicker td.available:hover,
+body.dark .daterangepicker th.available:hover {
+    background-color: #3b3b41;
+    color: #a3a3a3;
+}
+
+body.dark .daterangepicker td.off {
+    color: rgba(163, 163, 163, 0.4);
+}
+
+body.dark .daterangepicker td.in-range {
+    background-color: rgba(81, 73, 229, 0.3);
+    color: white;
+}
+
+body.dark .daterangepicker td.end-date {
+    background-color: #5149e5;
+}
+
+body.dark .daterangepicker select {
+    background-color: #3b3b41;
+    color: #a3a3a3;
+    border-color: #5f5f69;
+}
+
+body.dark .clockpicker-plate {
+    background-color: #3b3b41;
+    border-color: #3b3b41;
+}
+
+body.dark .clockpicker-tick {
+    color: #a3a3a3;
+}
+
+body.dark .img-thumbnail {
+    background-color: #323236;
+    border-color: #47474e;
+}
+
+body.dark .avatar .avatar-text {
+    background: #47474e;
+}
+
+body.dark .avatar.avatar-dark .avatar-text {
+    background-color: #1e1e21 !important;
+}
+
+body.dark .demo-icon-list:hover {
+    background: #3b3b41;
+}
+
+body.dark .jqvmap-region {
+    fill: rgba(81, 73, 229, 0.3);
+}
+
+body.dark .jqvmap-region:hover {
+    fill: #5149e5;
+}
+
+body.dark .list-group-item {
+    color: #a3a3a3;
+    background-color: #323236;
+    border-color: #47474e;
+}
+
+body.dark .list-group-item.active {
+    background-color: #5149e5;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+body.dark .list-group-item.active:hover {
+    color: rgba(255, 255, 255, 0.85);
+}
+
+body.dark .list-group-item-action {
+    color: #a3a3a3;
+}
+
+body.dark .list-group-item-action:hover {
+    color: #d7d7d7;
+}
+
+body.dark .mark,
+body.dark mark {
+    background-color: #47474e;
+    color: #a3a3a3;
+}
+
+body.dark .bg-image {
+    color: white;
+}
+
+body.dark .bg-image:before {
+    background: rgba(0, 0, 0, 0.4);
+}
+
+body.dark .row-vertical-border [class*=col-]:not(:last-child) {
+    border-right-color: #47474e;
+}
+
+body.dark.rtl .row-vertical-border [class*=col-]:not(:last-child) {
+    border-left-color: #47474e;
+}
+
+body.dark ::-moz-selection {
+    background-color: #5149e5;
+    color: white;
+}
+
+body.dark ::selection {
+    background-color: #5149e5;
+    color: white;
+}
+
+body.dark .apexcharts-svg {
+    background: none !important;
+}
+
+body.dark .bg-white {
+    background-color: #323236 !important;
+}
+
+body.dark .ql-snow .ql-stroke {
+    stroke: #a3a3a3;
+}
+
+body.dark .ql-snow .ql-fill,
+body.dark .ql-snow .ql-stroke.ql-fill {
+    fill: #a3a3a3;
+}
+
+body.dark .ql-snow.ql-toolbar button:hover .ql-stroke,
+body.dark .ql-snow .ql-toolbar button:hover .ql-stroke,
+body.dark .ql-snow.ql-toolbar button:focus .ql-stroke,
+body.dark .ql-snow .ql-toolbar button:focus .ql-stroke,
+body.dark .ql-snow.ql-toolbar button.ql-active .ql-stroke,
+body.dark .ql-snow .ql-toolbar button.ql-active .ql-stroke,
+body.dark .ql-snow.ql-toolbar .ql-picker-label:hover .ql-stroke,
+body.dark .ql-snow .ql-toolbar .ql-picker-label:hover .ql-stroke,
+body.dark .ql-snow.ql-toolbar .ql-picker-label.ql-active .ql-stroke,
+body.dark .ql-snow .ql-toolbar .ql-picker-label.ql-active .ql-stroke,
+body.dark .ql-snow.ql-toolbar .ql-picker-item:hover .ql-stroke,
+body.dark .ql-snow .ql-toolbar .ql-picker-item:hover .ql-stroke,
+body.dark .ql-snow.ql-toolbar .ql-picker-item.ql-selected .ql-stroke,
+body.dark .ql-snow .ql-toolbar .ql-picker-item.ql-selected .ql-stroke,
+body.dark .ql-snow.ql-toolbar button:hover .ql-stroke-miter,
+body.dark .ql-snow .ql-toolbar button:hover .ql-stroke-miter,
+body.dark .ql-snow.ql-toolbar button:focus .ql-stroke-miter,
+body.dark .ql-snow .ql-toolbar button:focus .ql-stroke-miter,
+body.dark .ql-snow.ql-toolbar button.ql-active .ql-stroke-miter,
+body.dark .ql-snow .ql-toolbar button.ql-active .ql-stroke-miter,
+body.dark .ql-snow.ql-toolbar .ql-picker-label:hover .ql-stroke-miter,
+body.dark .ql-snow .ql-toolbar .ql-picker-label:hover .ql-stroke-miter,
+body.dark .ql-snow.ql-toolbar .ql-picker-label.ql-active .ql-stroke-miter,
+body.dark .ql-snow .ql-toolbar .ql-picker-label.ql-active .ql-stroke-miter,
+body.dark .ql-snow.ql-toolbar .ql-picker-item:hover .ql-stroke-miter,
+body.dark .ql-snow .ql-toolbar .ql-picker-item:hover .ql-stroke-miter,
+body.dark .ql-snow.ql-toolbar .ql-picker-item.ql-selected .ql-stroke-miter,
+body.dark .ql-snow .ql-toolbar .ql-picker-item.ql-selected .ql-stroke-miter {
+    stroke: #d7d7d7;
+}
+
+body.dark .ql-snow.ql-toolbar button:hover .ql-fill,
+body.dark .ql-snow .ql-toolbar button:hover .ql-fill,
+body.dark .ql-snow.ql-toolbar button:focus .ql-fill,
+body.dark .ql-snow .ql-toolbar button:focus .ql-fill,
+body.dark .ql-snow.ql-toolbar button.ql-active .ql-fill,
+body.dark .ql-snow .ql-toolbar button.ql-active .ql-fill,
+body.dark .ql-snow.ql-toolbar .ql-picker-label:hover .ql-fill,
+body.dark .ql-snow .ql-toolbar .ql-picker-label:hover .ql-fill,
+body.dark .ql-snow.ql-toolbar .ql-picker-label.ql-active .ql-fill,
+body.dark .ql-snow .ql-toolbar .ql-picker-label.ql-active .ql-fill,
+body.dark .ql-snow.ql-toolbar .ql-picker-item:hover .ql-fill,
+body.dark .ql-snow .ql-toolbar .ql-picker-item:hover .ql-fill,
+body.dark .ql-snow.ql-toolbar .ql-picker-item.ql-selected .ql-fill,
+body.dark .ql-snow .ql-toolbar .ql-picker-item.ql-selected .ql-fill,
+body.dark .ql-snow.ql-toolbar button:hover .ql-stroke.ql-fill,
+body.dark .ql-snow .ql-toolbar button:hover .ql-stroke.ql-fill,
+body.dark .ql-snow.ql-toolbar button:focus .ql-stroke.ql-fill,
+body.dark .ql-snow .ql-toolbar button:focus .ql-stroke.ql-fill,
+body.dark .ql-snow.ql-toolbar button.ql-active .ql-stroke.ql-fill,
+body.dark .ql-snow .ql-toolbar button.ql-active .ql-stroke.ql-fill,
+body.dark .ql-snow.ql-toolbar .ql-picker-label:hover .ql-stroke.ql-fill,
+body.dark .ql-snow .ql-toolbar .ql-picker-label:hover .ql-stroke.ql-fill,
+body.dark .ql-snow.ql-toolbar .ql-picker-label.ql-active .ql-stroke.ql-fill,
+body.dark .ql-snow .ql-toolbar .ql-picker-label.ql-active .ql-stroke.ql-fill,
+body.dark .ql-snow.ql-toolbar .ql-picker-item:hover .ql-stroke.ql-fill,
+body.dark .ql-snow .ql-toolbar .ql-picker-item:hover .ql-stroke.ql-fill,
+body.dark .ql-snow.ql-toolbar .ql-picker-item.ql-selected .ql-stroke.ql-fill,
+body.dark .ql-snow .ql-toolbar .ql-picker-item.ql-selected .ql-stroke.ql-fill {
+    fill: #d7d7d7;
+}
+
+body.dark .email-list .list-group .list-group-item.active,
+body.dark .todo-list .list-group .list-group-item.active {
+    background-color: #323236;
+    color: inherit;
+}
+
+body.dark .nav-link {
+    color: #a3a3a3;
+}
+
+body.dark .nav-link:hover {
+    color: #d7d7d7;
+}
+
+body.dark .irs--round .irs-min,
+body.dark .irs--round .irs-max {
+    color: inherit;
+}
+
+body.dark .irs--round .irs-line {
+    background-color: #47474e;
+}
+
+body.dark .irs--round .irs-handle {
+    background-color: #47474e;
+}
+
+body.dark .swal2-popup {
+    background-color: #323236;
+}
+
+body.dark .swal2-title,
+body.dark .swal2-content {
+    color: #a3a3a3;
+}
+
+body.dark .swal2-footer {
+    border-top-color: #47474e;
+}
+
+body.dark .swal2-modal .swal2-actions .swal2-deny {
+    background-color: #47474e;
+    color: #a3a3a3;
+}
+
+body.dark .form-range::-webkit-slider-runnable-track {
+    background-color: #47474e;
+}
+
+body.dark .introjs-tooltip {
+    background-color: #323236;
+}
+
+body.dark .introjs-arrow.top {
+    border-bottom-color: #323236;
+}
+
+body.dark .introjs-arrow.bottom {
+    border-top-color: #323236;
+}
+
+body.dark .introjs-arrow.right {
+    border-left-color: #323236;
+}
+
+body.dark .introjs-arrow.left {
+    border-right-color: #323236;
+}
+
+body.dark .introjs-tooltipbuttons {
+    border-top-color: #47474e;
+}
+
+body.dark .introjs-button {
+    background-color: #3b3b41;
+    border-color: #47474e;
+}
+
+body.dark code {
+    color: #f371b2;
+}
+
+@media (max-width: 1000px) {
+    body.dark .chat-block .chat-content.chat-mobile-open {
+        background-color: #3b3b41;
+    }
+}
+
+@media (max-width: 1300px) {
+    .chat-block .chat-sidebar {
+        width: 350px;
+    }
+}
+
+@media (max-width: 1200px) {
+    .header .menu-toggle-btn {
+        display: block;
+    }
+
+    .header .header-mobile-buttons a.header-menu-btn {
+        display: block;
+    }
+
+    .header .header-menu {
+        opacity: 0;
+        box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+        position: fixed;
+        left: -110%;
+        top: 0;
+        bottom: 0;
+        overflow: auto;
+        width: 350px;
+        background: white;
+        z-index: 999;
+        padding: 0 30px;
+        transition: all 0.2s;
+    }
+
+    .header .header-menu-header {
+        display: flex !important;
+    }
+
+    .header .header-menu-header img {
+        width: 100px;
+    }
+
+    .header .header-menu .dropdown {
+        display: block;
+    }
+
+    .header .header-menu ul.navbar-nav {
+        display: block;
+        margin-left: 0;
+    }
+
+    .header .header-menu ul.navbar-nav li a {
+        color: black;
+        padding: 15px 30px !important;
+        height: auto !important;
+        margin-left: 0 !important;
+        border-right: 4px solid transparent;
+        border-left: 4px solid transparent;
+        border-radius: 5rem;
+    }
+
+    .header .header-menu ul.navbar-nav li a:before {
+        display: none !important;
+    }
+
+    .header .header-menu ul.navbar-nav li a .sub-menu-arrow {
+        margin-left: auto !important;
+    }
+
+    .header .header-menu ul.navbar-nav li a:hover {
+        color: black;
+        background: #f2f2f2 !important;
+    }
+
+    .header .header-menu ul.navbar-nav li a.active {
+        background: rgba(81, 73, 229, 0.15) !important;
+        color: #5149e5 !important;
+        border-left-color: #5149e5;
+        border-right-color: #5149e5;
+    }
+
+    .header .header-menu ul.navbar-nav li .nav-sub-menu {
+        visibility: visible !important;
+        opacity: 1 !important;
+        width: auto !important;
+        position: static !important;
+        padding: 0 !important;
+        margin-top: 0 !important;
+        display: none;
+        transform: scale(1) !important;
+    }
+
+    .header .header-menu ul.navbar-nav li .nav-sub-menu:after {
+        display: none !important;
+    }
+
+    .header .header-menu ul.navbar-nav li .nav-sub-menu ul {
+        box-shadow: none !important;
+        border: none !important;
+        padding: 0 !important;
+        border-radius: 0 !important;
+    }
+
+    .header .header-menu ul.navbar-nav li .nav-sub-menu ul li a {
+        padding-left: 58px !important;
+    }
+
+    .header .header-menu ul.navbar-nav li .nav-sub-menu ul li ul li a {
+        padding-left: 70px !important;
+    }
+
+    .header .header-menu ul.navbar-nav li.open>.nav-sub-menu {
+        display: block;
+    }
+
+    .header .header-menu.open {
+        left: 0;
+        opacity: 1;
+    }
+
+    .sidebar {
+        z-index: 1001;
+    }
+
+    .page-header>.container,
+    .bg-image>.container {
+        max-width: 100% !important;
+        padding: 0;
+    }
+
+    .layout-wrapper {
+        margin-left: 0;
+    }
+
+    .layout-wrapper .content>.container {
+        max-width: 100% !important;
+        padding: 0;
+    }
+
+    body.rtl .layout-wrapper {
+        margin-left: 0;
+        margin-right: 0;
+    }
+
+    .content-footer {
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+        padding-left: 20px !important;
+    }
+
+    .menu {
+        box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+        width: 350px;
+        position: fixed;
+        display: flex;
+        flex-direction: column;
+        left: -110% !important;
+        opacity: 0;
+        bottom: 0;
+        top: 0;
+        z-index: 9998 !important;
+        transition: all 0.2s;
+        background-color: white;
+    }
+
+    .menu .menu-close-btn {
+        display: block;
+    }
+
+    .menu.open {
+        left: 0 !important;
+        opacity: 1;
+    }
+
+    .menu-body {
+        overflow: auto;
+        border-radius: 0 !important;
+    }
+
+    .menu-body .dropdown {
+        background-color: #f5f4fe;
+    }
+
+    .menu-body ul li>a.active .nav-link-icon {
+        background-color: white;
+    }
+
+    body.rtl .menu {
+        left: auto !important;
+        right: -110% !important;
+    }
+
+    body.rtl .menu.open {
+        right: 0 !important;
+    }
+
+    body.header-menu .menu-body ul li a {
+        display: flex;
+        align-items: center;
+        padding: 10px 20px;
+    }
+
+    body.header-menu .menu-body ul li a .nav-link-icon {
+        margin-right: 0.8rem;
+    }
+
+    body.header-menu .menu-body ul li a .sub-menu-arrow {
+        margin-left: auto;
+        font-size: 10px;
+    }
+
+    body.header-menu .menu-body ul li a+ul li a {
+        padding-left: 50px !important;
+    }
+
+    .sidebar a.btn-sidebar-close {
+        display: flex !important;
+    }
+}
+
+@media (max-width: 1000px) {
+    .chat-block .chat-content {
+        display: none;
+        padding-left: 30px;
+        padding-right: 30px;
+        padding-bottom: 20px;
+    }
+
+    .chat-block .chat-content .chat-header {
+        padding: 0.5rem 1.5rem;
+    }
+
+    .chat-block .chat-content .mobile-chat-close-btn {
+        display: block;
+    }
+
+    .chat-block .chat-content.chat-mobile-open {
+        display: flex;
+        background-color: white;
+        position: absolute;
+        right: 0;
+        left: 0;
+        top: 0;
+        height: 100vh;
+        max-width: 100%;
+        z-index: 2;
+        bottom: 0;
+    }
+
+    .chat-block .chat-sidebar {
+        flex: 1;
+        border-right: none;
+        max-width: 100% !important;
+    }
+}
+
+@media (max-width: 768px) {
+    .header .logo {
+        display: none !important;
+    }
+
+    .header .header-mobile-buttons {
+        margin-left: auto;
+    }
+
+    .header .header-mobile-buttons a.actions-btn,
+    .header .header-mobile-buttons a.search-bar-btn {
+        display: flex;
+    }
+
+    .header .search-form .close-header-search-bar {
+        display: block;
+    }
+
+    .header .header-bar {
+        opacity: 0;
+        position: fixed;
+        background: white;
+        right: 0;
+        left: 0;
+        top: -180px;
+        height: 89px;
+        z-index: 9;
+        transition: all 0.2s;
+        padding: 0 20px;
+    }
+
+    .header .header-bar.open {
+        opacity: 1;
+        top: 0;
+    }
+
+    .card .card-body {
+        padding: 1.2rem;
+    }
+
+    .preloader img {
+        width: 140px;
+    }
+
+    .preloader .preloader-icon {
+        width: 35px;
+        height: 35px;
+    }
+
+    .chat-block .chat-content {
+        border-radius: 0.5rem;
+    }
+
+    .chat-block .chat-content .message-item {
+        padding-left: 0 !important;
+    }
+
+    .chat-block .chat-content .message-item.me {
+        padding-right: 0 !important;
+    }
+
+    .chat-block .chat-content .messages .message-item .time {
+        display: none;
+    }
+
+    .chat-block .chat-content .messages .message-item .message-item-content {
+        max-width: 100%;
+        background-color: #f2f2f2;
+    }
+
+    .buyer-profile-cover {
+        height: auto !important;
+    }
+
+    .toast-top-right {
+        top: 1rem;
+        right: 1rem;
+    }
+
+    .toast-top-left {
+        top: 1rem;
+        left: 1rem;
+    }
+
+    .header .search-form {
+        display: none;
+        margin-right: 0;
+        position: fixed;
+        background-color: rgba(0, 0, 0, 0.15);
+        right: 0;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        padding: 1.5rem;
+    }
+
+    .header .search-form.show {
+        display: block;
+    }
+
+    .header .page-title {
+        margin-right: 20px;
+    }
+
+    footer {
+        padding: 15px 20px;
+    }
+
+    footer .nav {
+        display: none;
+    }
+
+    .table-responsive-stack tr {
+        flex-direction: column;
+        border-bottom: 3px solid #ccc;
+        display: block;
+    }
+
+    /*  IE9 FIX   */
+    .table-responsive-stack td {
+        float: left \9;
+        width: 100%;
+    }
+
+    .sidebar>ul.nav {
+        display: flex;
+    }
+
+    .sidebar>ul.nav li.nav-item {
+        border: none;
+    }
+
+    .fc .fc-toolbar.fc-header-toolbar>div {
+        float: none !important;
+    }
+
+    .fc .fc-toolbar.fc-header-toolbar>div .fc-button-group {
+        float: none !important;
+    }
+
+    .fc .fc-toolbar.fc-header-toolbar>div.fc-left {
+        display: flex;
+        justify-content: center;
+        margin-bottom: 15px;
+    }
+
+    .fc .fc-toolbar.fc-header-toolbar>div.fc-right {
+        margin-bottom: 5px;
+    }
+}
+
+@media (max-width: 600px) {
+    .dataTables_wrapper .dataTables_filter {
+        display: block;
+    }
+
+    .dataTables_wrapper .dataTables_length {
+        margin-bottom: 15px;
+    }
+
+    .dataTables_wrapper div.dataTables_paginate ul.pagination {
+        justify-content: center !important;
+        margin-top: 15px !important;
+    }
+
+    .timeline .timeline-item {
+        display: block;
+    }
+
+    .timeline .timeline-item:before {
+        display: none;
+    }
+
+    .timeline .timeline-item .avatar {
+        margin: auto;
+        margin-right: auto !important;
+        text-align: center;
+        display: table;
+        margin-bottom: 20px;
+    }
+}
+
+@media (max-width: 540px) {
+    .menu {
+        width: 100% !important;
+        right: 0;
+    }
+
+    .menu-body {
+        padding: 20px;
+    }
+
+    .chat-block {
+        height: calc(100vh - 185px);
+    }
+
+    .header .header-menu {
+        width: 100%;
+    }
+
+    .sidebar {
+        width: 100%;
+    }
+
+    .wizard>.steps>ul>li {
+        float: none;
+        width: 100%;
+        margin-bottom: 10px;
+    }
+
+    .wizard>.content {
+        background: none;
+    }
+
+    .wizard>.content>.body {
+        position: static;
+        padding: 1.2rem;
+    }
+}
+
+@media print {
+
+    .menu,
+    .header,
+    .page-header,
+    .content-footer {
+        display: none !important;
+    }
+}
+
+*:focus {
+    outline: none;
+}
+
+a {
+    text-decoration: none;
+    color: #291fdc;
+}
+
+code[class*=language-],
+pre[class*=language-] {
+    text-shadow: none;
+}
+
+::-moz-selection {
+    background-color: #d1cff8;
+}
+
+::selection {
+    background-color: #d1cff8;
+}
+
+.accordion-button {
+    text-align: left;
+    align-items: start;
+}
+
+.ql-container {
+    height: auto;
+}
+
+.ql-container.ql-snow {
+    border-radius: 0.5rem;
+}
+
+.tooltip {
+    pointer-events: none;
+}
+
+.tooltip .arrow {
+    display: none;
+}
+
+.nav.nav-pills .nav-item .nav-link.active {
+    background: rgba(81, 73, 229, 0.15);
+    color: #5149e5;
+}
+
+.nav-link:not(.active) {
+    color: #666;
+}
+
+.nav-link:not(.active):hover {
+    color: black;
+}
+
+.bootstrap-tagsinput {
+    box-shadow: none;
+    width: 100%;
+    border: 1px solid #ced4da;
+    min-height: calc(2.25rem + 2px);
+}
+
+.bootstrap-tagsinput.focus {
+    box-shadow: 0 0 0 1px #5149e5;
+    border-color: rgba(81, 73, 229, 0.8) !important;
+}
+
+.bootstrap-tagsinput .tag {
+    display: inline-flex;
+    color: black;
+    border-radius: 3px;
+    font-size: 13px;
+    padding: 0 8px;
+    margin: 2px 1px;
+    justify-content: space-between;
+    align-items: center;
+    background-color: #e4e4e4;
+}
+
+h1,
+.h1,
+h2,
+.h2,
+h3,
+.h3,
+h4,
+.h4,
+h5,
+.h5 {
+    line-height: revert;
+}
+
+.bd-example {
+    border-width: 0;
+    margin: 0;
+    padding: 0;
+}
+
+.bd-example-modal {
+    background: none;
+}
+
+.input-group-text {
+    background: #ededed;
+}
+
+.bg-cyan-100 {
+    background-color: #cff4fc !important;
+}
+
+.profile-cover {
+    padding: 30px 20px;
+    height: 350px;
+    border-radius: 0.5rem;
+}
+
+.buyer-profile-cover {
+    padding: 30px 20px;
+    height: 200px;
+    border-radius: 0.5rem;
+}
+
+.bg-image {
+    background-size: cover !important;
+    background-position: center !important;
+    position: relative;
+    overflow: hidden;
+}
+
+.bg-image:before {
+    content: "";
+    display: block;
     position: absolute;
     right: 0;
     left: 0;
     top: 0;
-    height: 100vh;
-    max-width: 100%;
-    z-index: 2;
     bottom: 0;
-  }
-  .chat-block .chat-sidebar {
-    flex: 1;
-    border-right: none;
-    max-width: 100% !important;
-  }
+    background: rgba(255, 255, 255, 0.4);
 }
-@media (max-width: 768px) {
-  .header .logo {
-    display: none !important;
-  }
-  .header .header-mobile-buttons {
-    margin-left: auto;
-  }
-  .header .header-mobile-buttons a.actions-btn, .header .header-mobile-buttons a.search-bar-btn {
+
+.bg-image>* {
+    position: relative;
+    z-index: 1;
+}
+
+.email-list .list-group .list-group-item,
+.todo-list .list-group .list-group-item {
     display: flex;
-  }
-  .header .search-form .close-header-search-bar {
-    display: block;
-  }
-  .header .header-bar {
-    opacity: 0;
-    position: fixed;
-    background: white;
-    right: 0;
-    left: 0;
-    top: -180px;
-    height: 89px;
-    z-index: 9;
-    transition: all 0.2s;
-    padding: 0 20px;
-  }
-  .header .header-bar.open {
-    opacity: 1;
-    top: 0;
-  }
-  .card .card-body {
-    padding: 1.2rem;
-  }
-  .preloader img {
-    width: 140px;
-  }
-  .preloader .preloader-icon {
-    width: 35px;
-    height: 35px;
-  }
-  .chat-block .chat-content {
+    align-items: center;
     border-radius: 0.5rem;
-  }
-  .chat-block .chat-content .message-item {
-    padding-left: 0 !important;
-  }
-  .chat-block .chat-content .message-item.me {
-    padding-right: 0 !important;
-  }
-  .chat-block .chat-content .messages .message-item .time {
-    display: none;
-  }
-  .chat-block .chat-content .messages .message-item .message-item-content {
-    max-width: 100%;
-    background-color: #f2f2f2;
-  }
-  .buyer-profile-cover {
-    height: auto !important;
-  }
-  .toast-top-right {
-    top: 1rem;
-    right: 1rem;
-  }
-  .toast-top-left {
-    top: 1rem;
-    left: 1rem;
-  }
-  .header .search-form {
-    display: none;
-    margin-right: 0;
-    position: fixed;
-    background-color: rgba(0, 0, 0, 0.15);
-    right: 0;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    padding: 1.5rem;
-  }
-  .header .search-form.show {
-    display: block;
-  }
-  .header .page-title {
-    margin-right: 20px;
-  }
-  footer {
-    padding: 15px 20px;
-  }
-  footer .nav {
-    display: none;
-  }
-  .table-responsive-stack tr {
-    flex-direction: column;
-    border-bottom: 3px solid #ccc;
-    display: block;
-  }
-  /*  IE9 FIX   */
-  .table-responsive-stack td {
-    float: left \9 ;
-    width: 100%;
-  }
-  .sidebar > ul.nav {
-    display: flex;
-  }
-  .sidebar > ul.nav li.nav-item {
-    border: none;
-  }
-  .fc .fc-toolbar.fc-header-toolbar > div {
-    float: none !important;
-  }
-  .fc .fc-toolbar.fc-header-toolbar > div .fc-button-group {
-    float: none !important;
-  }
-  .fc .fc-toolbar.fc-header-toolbar > div.fc-left {
-    display: flex;
-    justify-content: center;
-    margin-bottom: 15px;
-  }
-  .fc .fc-toolbar.fc-header-toolbar > div.fc-right {
-    margin-bottom: 5px;
-  }
-}
-@media (max-width: 600px) {
-  .dataTables_wrapper .dataTables_filter {
-    display: block;
-  }
-  .dataTables_wrapper .dataTables_length {
-    margin-bottom: 15px;
-  }
-  .dataTables_wrapper div.dataTables_paginate ul.pagination {
-    justify-content: center !important;
-    margin-top: 15px !important;
-  }
-  .timeline .timeline-item {
-    display: block;
-  }
-  .timeline .timeline-item:before {
-    display: none;
-  }
-  .timeline .timeline-item .avatar {
-    margin: auto;
-    margin-right: auto !important;
-    text-align: center;
-    display: table;
     margin-bottom: 20px;
-  }
-}
-@media (max-width: 540px) {
-  .menu {
-    width: 100% !important;
-    right: 0;
-  }
-  .menu-body {
-    padding: 20px;
-  }
-  .chat-block {
-    height: calc(100vh - 185px);
-  }
-  .header .header-menu {
-    width: 100%;
-  }
-  .sidebar {
-    width: 100%;
-  }
-  .wizard > .steps > ul > li {
-    float: none;
-    width: 100%;
-    margin-bottom: 10px;
-  }
-  .wizard > .content {
-    background: none;
-  }
-  .wizard > .content > .body {
-    position: static;
-    padding: 1.2rem;
-  }
-}
-@media print {
-  .menu, .header, .page-header, .content-footer {
-    display: none !important;
-  }
-}
-*:focus {
-  outline: none;
+    padding: 15px 20px;
+    margin-top: 0;
+    border-width: 0 !important;
 }
 
-a {
-  text-decoration: none;
-  color: #291fdc;
-}
-
-code[class*=language-], pre[class*=language-] {
-  text-shadow: none;
-}
-
-::-moz-selection {
-  background-color: #d1cff8;
-}
-
-::selection {
-  background-color: #d1cff8;
-}
-
-.accordion-button {
-  text-align: left;
-  align-items: start;
-}
-
-.ql-container {
-  height: auto;
-}
-.ql-container.ql-snow {
-  border-radius: 0.5rem;
-}
-
-.tooltip {
-  pointer-events: none;
-}
-.tooltip .arrow {
-  display: none;
-}
-
-.nav.nav-pills .nav-item .nav-link.active {
-  background: rgba(81, 73, 229, 0.15);
-  color: #5149e5;
-}
-
-.nav-link:not(.active) {
-  color: #666;
-}
-.nav-link:not(.active):hover {
-  color: black;
-}
-
-.bootstrap-tagsinput {
-  box-shadow: none;
-  width: 100%;
-  border: 1px solid #ced4da;
-  min-height: calc(2.25rem + 2px);
-}
-.bootstrap-tagsinput.focus {
-  box-shadow: 0 0 0 1px #5149e5;
-  border-color: rgba(81, 73, 229, 0.8) !important;
-}
-.bootstrap-tagsinput .tag {
-  display: inline-flex;
-  color: black;
-  border-radius: 3px;
-  font-size: 13px;
-  padding: 0 8px;
-  margin: 2px 1px;
-  justify-content: space-between;
-  align-items: center;
-  background-color: #e4e4e4;
-}
-
-h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5 {
-  line-height: revert;
-}
-
-.bd-example {
-  border-width: 0;
-  margin: 0;
-  padding: 0;
-}
-
-.bd-example-modal {
-  background: none;
-}
-
-.input-group-text {
-  background: #ededed;
-}
-
-.bg-cyan-100 {
-  background-color: #cff4fc !important;
-}
-
-.profile-cover {
-  padding: 30px 20px;
-  height: 350px;
-  border-radius: 0.5rem;
-}
-
-.buyer-profile-cover {
-  padding: 30px 20px;
-  height: 200px;
-  border-radius: 0.5rem;
-}
-
-.bg-image {
-  background-size: cover !important;
-  background-position: center !important;
-  position: relative;
-  overflow: hidden;
-}
-.bg-image:before {
-  content: "";
-  display: block;
-  position: absolute;
-  right: 0;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  background: rgba(255, 255, 255, 0.4);
-}
-.bg-image > * {
-  position: relative;
-  z-index: 1;
-}
-
-.email-list .list-group .list-group-item, .todo-list .list-group .list-group-item {
-  display: flex;
-  align-items: center;
-  border-radius: 0.5rem;
-  margin-bottom: 20px;
-  padding: 15px 20px;
-  margin-top: 0;
-  border-width: 0 !important;
-}
-.email-list .list-group .list-group-item.active, .todo-list .list-group .list-group-item.active {
-  z-index: auto;
-  color: black;
-  background: white;
-  box-shadow: 0 0 0 1px #5149e5 !important;
-  border-color: transparent;
+.email-list .list-group .list-group-item.active,
+.todo-list .list-group .list-group-item.active {
+    z-index: auto;
+    color: black;
+    background: white;
+    box-shadow: 0 0 0 1px #5149e5 !important;
+    border-color: transparent;
 }
 
 .modal-content {
-  border-radius: 0.5rem;
-  border: none;
+    border-radius: 0.5rem;
+    border: none;
 }
 
 .todo-list .list-group .list-group-item.todo-completed {
-  box-shadow: 0 0 0 1px #05b171;
-  border-color: transparent;
+    box-shadow: 0 0 0 1px #05b171;
+    border-color: transparent;
 }
 
 .ql-toolbar.ql-snow {
-  border: none;
-  padding: 0;
+    border: none;
+    padding: 0;
 }
 
 .todo-sortable-handle {
-  cursor: move;
+    cursor: move;
 }
 
 .input-group .btn.btn-light {
-  border-color: #ced4da;
-}
-.input-group .btn.btn-outline-light {
-  border-color: #ced4da;
-  background: white;
-  border-right-color: transparent;
-}
-.input-group .form-control + .btn.btn-outline-light, .input-group .swal2-modal .swal2-input + .btn.btn-outline-light, .swal2-modal .input-group .swal2-input + .btn.btn-outline-light {
-  border-left-color: transparent;
-  border-right-color: #ced4da;
+    border-color: #ced4da;
 }
 
-.bd-content > h4, .bd-content > .h4 {
-  margin-top: 3rem;
+.input-group .btn.btn-outline-light {
+    border-color: #ced4da;
+    background: white;
+    border-right-color: transparent;
 }
-.bd-content > h5, .bd-content > .h5 {
-  margin-top: 1.5rem;
+
+.input-group .form-control+.btn.btn-outline-light,
+.input-group .swal2-modal .swal2-input+.btn.btn-outline-light,
+.swal2-modal .input-group .swal2-input+.btn.btn-outline-light {
+    border-left-color: transparent;
+    border-right-color: #ced4da;
 }
-.bd-content > .card {
-  margin-top: 1rem;
-  margin-bottom: 1rem;
+
+.bd-content>h4,
+.bd-content>.h4 {
+    margin-top: 3rem;
 }
-.bd-content > .card:last-child {
-  margin-bottom: 0;
+
+.bd-content>h5,
+.bd-content>.h5 {
+    margin-top: 1.5rem;
+}
+
+.bd-content>.card {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+}
+
+.bd-content>.card:last-child {
+    margin-bottom: 0;
 }
 
 #TableOfContents ul li a:hover {
-  text-decoration: underline;
-  color: black;
+    text-decoration: underline;
+    color: black;
 }
 
 .color-filter-group .form-check-input {
-  width: 1.5em !important;
-  height: 1.5em !important;
-  border-color: transparent;
+    width: 1.5em !important;
+    height: 1.5em !important;
+    border-color: transparent;
 }
 
 .slick-wrapper {
-  padding: 0 30px;
+    padding: 0 30px;
 }
-.slick-wrapper .slick-prev, .slick-wrapper .slick-next {
-  z-index: 1;
-}
-.slick-wrapper .slick-prev:before, .slick-wrapper .slick-prev:before, .slick-wrapper .slick-next:before, .slick-wrapper .slick-next:before {
-  color: black;
-  opacity: 0.5;
-}
-.slick-wrapper .slick-prev:hover:before, .slick-wrapper .slick-prev:hover:before, .slick-wrapper .slick-next:hover:before, .slick-wrapper .slick-next:hover:before {
-  opacity: 1;
-}
+
+.slick-wrapper .slick-prev,
 .slick-wrapper .slick-next {
-  right: -30px;
+    z-index: 1;
 }
+
+.slick-wrapper .slick-prev:before,
+.slick-wrapper .slick-prev:before,
+.slick-wrapper .slick-next:before,
+.slick-wrapper .slick-next:before {
+    color: black;
+    opacity: 0.5;
+}
+
+.slick-wrapper .slick-prev:hover:before,
+.slick-wrapper .slick-prev:hover:before,
+.slick-wrapper .slick-next:hover:before,
+.slick-wrapper .slick-next:hover:before {
+    opacity: 1;
+}
+
+.slick-wrapper .slick-next {
+    right: -30px;
+}
+
 .slick-wrapper .slick-prev {
-  left: -30px;
+    left: -30px;
 }
+
 .slick-wrapper .slick-nav-wrapper .slick-slide img {
-  border: 1px solid transparent;
+    border: 1px solid transparent;
 }
+
 .slick-wrapper .slick-nav-wrapper .slick-slide.slick-current img {
-  border-color: #5149e5;
+    border-color: #5149e5;
 }
 
 .icon-lg {
-  font-size: 1.2rem !important;
-  line-height: 1.2rem !important;
+    font-size: 1.2rem !important;
+    line-height: 1.2rem !important;
 }
+
 .icon-xl {
-  font-size: 1.7rem !important;
-  line-height: 1.7rem !important;
+    font-size: 1.7rem !important;
+    line-height: 1.7rem !important;
 }
+
 .icon-xxl {
-  font-size: 2.2rem !important;
-  line-height: 2.2rem !important;
+    font-size: 2.2rem !important;
+    line-height: 2.2rem !important;
 }
 
 .btn {
-  font-size: 14px;
+    font-size: 14px;
 }
+
 .btn.btn-outline-light {
-  color: black !important;
+    color: black !important;
 }
+
 .btn.btn-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
+
 .btn.btn-icon i {
-  margin-right: 9px;
+    margin-right: 9px;
 }
 
 .ql-editor {
-  min-height: 80px;
+    min-height: 80px;
 }
 
 .dropzone {
-  border-radius: 0.5rem;
+    border-radius: 0.5rem;
 }
 
-.jqvmap-zoomin, .jqvmap-zoomout {
-  box-sizing: initial;
+.jqvmap-zoomin,
+.jqvmap-zoomout {
+    box-sizing: initial;
 }
 
 .apexcharts-canvas {
-  margin: auto;
+    margin: auto;
 }
 
 .jqvmap-region {
-  fill: #a6a2f2;
+    fill: #a6a2f2;
 }
+
 .jqvmap-region:hover {
-  fill: #5149e5;
+    fill: #5149e5;
 }
 
 .row-vertical-border [class*=col-]:not(:last-child) {
-  border-right: 1px solid #dee2e6;
+    border-right: 1px solid #dee2e6;
 }
 
 .rate-list .list-inline-item {
-  margin-right: 0;
+    margin-right: 0;
 }
 
 .circle canvas {
-  vertical-align: top;
+    vertical-align: top;
 }
 
 .swal2-progress-steps .swal2-progress-step {
-  background: #5149e5 !important;
+    background: #5149e5 !important;
 }
 
 .swal2-progress-steps .swal2-progress-step.swal2-active-progress-step {
-  background: #5149e5 !important;
+    background: #5149e5 !important;
 }
 
 .swal2-progress-steps .swal2-progress-step-line {
-  background: #5149e5 !important;
+    background: #5149e5 !important;
 }
 
-.swal2-progress-steps .swal2-progress-step.swal2-active-progress-step ~ .swal2-progress-step-line {
-  background: rgba(81, 73, 229, 0.3) !important;
+.swal2-progress-steps .swal2-progress-step.swal2-active-progress-step~.swal2-progress-step-line {
+    background: rgba(81, 73, 229, 0.3) !important;
 }
 
-.swal2-progress-steps .swal2-progress-step.swal2-active-progress-step ~ .swal2-progress-step {
-  background: rgba(81, 73, 229, 0.3) !important;
+.swal2-progress-steps .swal2-progress-step.swal2-active-progress-step~.swal2-progress-step {
+    background: rgba(81, 73, 229, 0.3) !important;
 }
 
 .ck-editor__editable_inline {
-  min-height: 230px;
+    min-height: 230px;
 }
 
 .ck.ck-list__item .ck-button.ck-on {
-  background: #5149e5;
+    background: #5149e5;
 }
 
 .text-white-60 {
-  color: rgba(255, 255, 255, 0.6) !important;
+    color: rgba(255, 255, 255, 0.6) !important;
 }
 
 .text-white-70 {
-  color: rgba(255, 255, 255, 0.7) !important;
+    color: rgba(255, 255, 255, 0.7) !important;
 }
 
 .text-white-80 {
-  color: rgba(255, 255, 255, 0.8) !important;
+    color: rgba(255, 255, 255, 0.8) !important;
 }
 
 .text-white-90 {
-  color: rgba(255, 255, 255, 0.9) !important;
+    color: rgba(255, 255, 255, 0.9) !important;
 }
 
 .nicescroll-cursors {
-  background-color: rgba(81, 73, 229, 0.15) !important;
-  width: 6px !important;
-  border: none !important;
-  right: 3px !important;
-  z-index: 2;
+    background-color: rgba(81, 73, 229, 0.15) !important;
+    width: 6px !important;
+    border: none !important;
+    right: 3px !important;
+    z-index: 2;
 }
 
 .apexcharts-legend.position-top.center {
-  justify-content: flex-end !important;
+    justify-content: flex-end !important;
 }
 
 .sticky-top {
-  top: 90px;
-  z-index: 996;
+    top: 90px;
+    z-index: 996;
 }
 
 blockquote * {
-  line-height: inherit;
+    line-height: inherit;
 }
 
 .bg-facebook {
-  background: #3b5998;
-  color: white;
+    background: #3b5998;
+    color: white;
 }
 
 .bg-twitter {
-  background: #55acee;
-  color: white;
+    background: #55acee;
+    color: white;
 }
 
 .bg-google {
-  background: #db4437;
-  color: white;
+    background: #db4437;
+    color: white;
 }
 
 .bg-pinterest {
-  background: #bd081c;
-  color: white;
+    background: #bd081c;
+    color: white;
 }
 
 .bg-linkedin {
-  background: #0077b5;
-  color: white;
+    background: #0077b5;
+    color: white;
 }
 
 .bg-whatsapp {
-  background: #43d854;
-  color: white;
+    background: #43d854;
+    color: white;
 }
 
 .bg-github {
-  background: #00405d;
-  color: white;
+    background: #00405d;
+    color: white;
 }
 
 .bg-behance {
-  background: #1769ff;
-  color: white;
+    background: #1769ff;
+    color: white;
 }
 
 .bg-skype {
-  background: #00aff0;
-  color: white;
+    background: #00aff0;
+    color: white;
 }

--- a/pages/.html
+++ b/pages/.html
@@ -19,6 +19,9 @@
     <!-- Slick -->
     <link rel="stylesheet" href="../libs/slick/slick.css" type="text/css">
 
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/404.html
+++ b/pages/404.html
@@ -9,6 +9,9 @@
     <!-- Favicon -->
     <link rel="shortcut icon" href="../images/favicon.png"/>
 
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/access-denied.html
+++ b/pages/access-denied.html
@@ -17,6 +17,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
     
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/bootstrap-demo.html
+++ b/pages/bootstrap-demo.html
@@ -19,6 +19,9 @@
     <!-- Slick -->
     <link rel="stylesheet" href="../libs/slick/slick.css" type="text/css">
 
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/buyer-addresses.html
+++ b/pages/buyer-addresses.html
@@ -17,6 +17,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
     
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/buyer-dashboard.html
+++ b/pages/buyer-dashboard.html
@@ -17,6 +17,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
     
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/buyer-orders.html
+++ b/pages/buyer-orders.html
@@ -17,6 +17,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
     
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/buyer-wishlist.html
+++ b/pages/buyer-wishlist.html
@@ -17,6 +17,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
     
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/chats.html
+++ b/pages/chats.html
@@ -17,6 +17,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
     
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/checkout.html
+++ b/pages/checkout.html
@@ -19,6 +19,9 @@
     <!-- Form wizard -->
     <link rel="stylesheet" href="../libs/form-wizard/jquery.steps.css" type="text/css">
 
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/customers.html
+++ b/pages/customers.html
@@ -18,6 +18,9 @@
 
     
 
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -13,6 +13,9 @@
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600&display=swap" rel="stylesheet">
 
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Bootstrap icons -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 

--- a/pages/email-detail.html
+++ b/pages/email-detail.html
@@ -22,6 +22,9 @@
     <!-- Tagsinput -->
     <link rel="stylesheet" href="../libs/tagsinput/bootstrap-tagsinput.css" type="text/css">
 
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/email.html
+++ b/pages/email.html
@@ -22,6 +22,9 @@
     <!-- Tagsinput -->
     <link rel="stylesheet" href="../libs/tagsinput/bootstrap-tagsinput.css" type="text/css">
 
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -17,6 +17,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
     
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/invoice-detail.html
+++ b/pages/invoice-detail.html
@@ -17,6 +17,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
     
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/invoices.html
+++ b/pages/invoices.html
@@ -17,6 +17,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
     
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/order-detail.html
+++ b/pages/order-detail.html
@@ -17,6 +17,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
     
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/orders.html
+++ b/pages/orders.html
@@ -17,6 +17,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
     
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/pricing-table.html
+++ b/pages/pricing-table.html
@@ -17,6 +17,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
     
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/product-detail.html
+++ b/pages/product-detail.html
@@ -23,6 +23,9 @@
     <!-- Rating -->
     <link rel="stylesheet" href="../libs/rating/rating.min.css" type="text/css">
 
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/product-grid.html
+++ b/pages/product-grid.html
@@ -19,6 +19,9 @@
     <!-- Range slider -->
     <link rel="stylesheet" href="../libs/range-slider/css/ion.rangeSlider.min.css" type="text/css">
 
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/product-list.html
+++ b/pages/product-list.html
@@ -19,6 +19,9 @@
     <!-- Range slider -->
     <link rel="stylesheet" href="../libs/range-slider/css/ion.rangeSlider.min.css" type="text/css">
 
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/profile-connections.html
+++ b/pages/profile-connections.html
@@ -17,6 +17,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
     
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/profile-posts.html
+++ b/pages/profile-posts.html
@@ -17,6 +17,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
     
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/search-page.html
+++ b/pages/search-page.html
@@ -19,6 +19,9 @@
     <!-- Lightbox -->
     <link rel="stylesheet" href="../libs/lightbox/magnific-popup.css" type="text/css">
 
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/settings.html
+++ b/pages/settings.html
@@ -17,6 +17,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
     
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/shopping-cart.html
+++ b/pages/shopping-cart.html
@@ -17,6 +17,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
     
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/todo-detail.html
+++ b/pages/todo-detail.html
@@ -28,6 +28,9 @@
     <!-- Select2 -->
     <link rel="stylesheet" href="../libs/select2/css/select2.min.css" type="text/css">
 
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/todo-list.html
+++ b/pages/todo-list.html
@@ -28,6 +28,9 @@
     <!-- Select2 -->
     <link rel="stylesheet" href="../libs/select2/css/select2.min.css" type="text/css">
 
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/under-construction.html
+++ b/pages/under-construction.html
@@ -9,6 +9,9 @@
     <!-- Favicon -->
     <link rel="shortcut icon" href="../images/favicon.png"/>
 
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/user-grid.html
+++ b/pages/user-grid.html
@@ -17,6 +17,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
     
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>

--- a/pages/user-list.html
+++ b/pages/user-list.html
@@ -17,6 +17,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
     
+    <!-- Bootstrap stylesheet -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+
     <!-- Main style file -->
     <link rel="stylesheet" href="../css/app.css" type="text/css">
 </head>


### PR DESCRIPTION
This was a rushed hack job done by hand by Diff-checking the CSS files of Bootstrap and the project, so I may have missed a few lines, but everything appears to be in order for the most part. This was not an easy task as I did not automate the process. 

Bootstrap stylesheets shouldn't be edited directly, but rather be referenced to be cached on the user's browsers, and then necessary modifications be performed in their own stylesheets. This revises the project so that can be done.

Several issues this Pull Request does not fix:
- The app.css stylesheet is NOT dark-mode friendly and renders most content as a forced light theme, as certain colors are defined without regard to the theme, after about [line 1439](https://github.com/AzzieDev/adminbold/blob/31131194866a2c001db4f4ac194c6d0ad025daf4/css/app.css#L1439) which was [Line 11999 of original](https://github.com/bundui/adminbold/blob/a0ab2a15db2ca3f394af21e88ab66beefab18b22/css/app.css#L11999).
- If the user opens the Notification bar when they have scrolled down in desktop view, the bar can not be closed as the button is only visible at the top. The element needs to be stickied or have some other style modification to prevent this issue.
- The navigation, headers, footers, and such are duplicated for each page that uses it and would need to be edited individually for each page to have an identical. There are many solutions to this problem, such as using a wrapper page and dynamically loading the page contents using vanilla JavaScript, using dedicated libraries within web frameworks like Angular, Vue, or React, or using PHP for handling the headers and footers.
